### PR TITLE
Expand TransformSolver edge case tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,150 @@
-# cesium-gizmo-demo
+# Universal Manipulator for Cesium Scenes
+
+This project delivers a reusable TypeScript manipulator library that mimics the behaviour of professional DCC gizmos while remaining self-contained and renderable without full Cesium assets. It provides the following:
+
+- A composable `UniversalManipulator` class.
+- Modular components for picking, frame resolution, snapping, HUD feedback, and pivot management.
+- A canvas-based renderer that keeps handles visible and screen-space sized.
+- A complete example application (no build step required) demonstrating translate, rotate, and scale modes with orientation and pivot switching.
+- Automated unit tests covering the most critical math primitives.
+
+> **Note**: The demo uses a lightweight canvas renderer so it can run inside this environment. When integrating with Cesium proper you can replace or augment the renderer with real Cesium primitives while reusing the maths, controller and snapping infrastructure from this library.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js ≥ 18 (provides the `node --test` runner used by the unit tests).
+- The repository ships with TypeScript globally available within the execution environment (`tsc`).
+
+### Install & Build
+
+No external dependencies are required. Compile the TypeScript sources once to generate the ESM modules in `dist/`:
+
+```bash
+npm run build
+```
+
+This command emits library code, tests and example assets into `dist/`.
+
+### Run Tests
+
+After building, execute the automated math tests:
+
+```bash
+npm test
+```
+
+The tests validate the key numerical behaviours (axis translation, rotation stability and pivot resolution).
+
+### Launch the Example
+
+1. Build the project (`npm run build`).
+2. Serve the repository root with a static server of your choice (for example, `python3 -m http.server`).
+3. Open `example/index.html` in your browser.
+
+The example scene allows you to drag handles, switch orientation/pivot, and observe snap modifiers (`Shift` for fine, `Ctrl/⌘` for coarse). Undo/redo are mapped to the side panel buttons and keyboard shortcuts (`Ctrl/⌘+Z`, `Ctrl/⌘+Y`).
+
+## Library Usage
+
+```ts
+import {
+  UniversalManipulator,
+  createPerspectiveCamera,
+  MatrixTransformTarget,
+  updateCameraViewport,
+  Orientation,
+  Pivot
+} from 'cesium-gizmo-demo';
+
+const container = document.getElementById('canvas-host')!;
+const camera = createPerspectiveCamera({
+  position: new Vector3(50, 40, 40),
+  lookAt: new Vector3(0, 0, 0),
+  viewportWidth: container.clientWidth,
+  viewportHeight: container.clientHeight,
+  aspect: container.clientWidth / container.clientHeight
+});
+
+const target = new MatrixTransformTarget(Matrix4.fromTranslationRotationScale(
+  new Vector3(0, 0, 0),
+  Quaternion.identity(),
+  new Vector3(1, 1, 1)
+));
+
+const manipulator = new UniversalManipulator(
+  { target, orientation: 'global', pivot: 'origin' },
+  { camera, container }
+);
+
+// Change orientation/pivot at runtime
+manipulator.setOrientation('local');
+manipulator.setPivot('median');
+
+// Enable/disable modes
+manipulator.enable({ scale: false });
+
+// Update camera viewport when the host element resizes
+updateCameraViewport(camera, container.clientWidth, container.clientHeight);
+manipulator.setShow(true);
+```
+
+### API Summary
+
+- **`UniversalManipulator`**
+  - `setTarget(target | target[])`
+  - `setOrientation(orientation: Orientation)`
+  - `setPivot(pivot: Pivot)`
+  - `enable({ translate?, rotate?, scale? })`
+  - `setSnap(stepConfig)`
+  - `setSize({ screenPixelRadius, minScale, maxScale })`
+  - `setShow(visible)`
+  - `undo()` / `redo()`
+  - `destroy()`
+- **`MatrixTransformTarget`** – simple matrix-backed target adapter useful for plain objects or tests.
+- **`createPerspectiveCamera` / `updateCameraViewport`** – helper utilities to maintain the minimal camera state required by the manipulator.
+
+### Snapping & Modifiers
+
+Snap behaviour can be fully configured via `setSnap`. During interaction:
+
+- Hold **Shift** for fine adjustments (`fineModifier`).
+- Hold **Ctrl** / **⌘** for coarse adjustments (`coarseModifier`).
+- Release modifiers to revert to the base step sizes.
+
+The HUD overlay shows the effective axis, deltas, and whether snapping is active.
+
+## Testing Strategy
+
+The included tests cover:
+
+- Axis translations and rotations via the `TransformSolver` with strict error tolerances (`1e-5`).
+- Pivot resolution rules (median, individual) ensuring correctness for multi-target editing.
+
+Additional behaviours (controller state machine, renderer) can be validated through the example application.
+
+## Project Structure
+
+```
+src/
+  core/            # Controllers, pickers, renderer, solver, frame builder
+  math/            # Minimal math primitives (vectors, matrices, quaternions)
+  utils/           # Transform helpers and geodesy utilities
+  UniversalManipulator.ts
+  index.ts         # Public exports
+example/
+  index.html       # Demo UI
+  main.ts          # Example bootstrapping logic
+tests/
+  *.test.ts        # Unit tests executed via node:test
+```
+
+## Limitations & Integration Notes
+
+- The demo renderer is 2D canvas-based. Replace `GizmoRenderer` with Cesium primitives for production usage to leverage depth, lighting, and actual 3D assets.
+- `MatrixTransformTarget` manipulates absolute matrices; for hierarchical scenes ensure you adapt the interface to respect parent transforms.
+- The library uses double precision math and avoids per-frame allocations to stay performant, but profiling is recommended when integrating with large scenes.
+
+## License
+
+This repository is distributed under the MIT License.

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Universal Manipulator Demo</title>
+    <style>
+      body {
+        margin: 0;
+        background: #0b1120;
+        color: #f7fafc;
+        font-family: sans-serif;
+        display: flex;
+        height: 100vh;
+      }
+      #sidebar {
+        width: 280px;
+        padding: 16px;
+        box-sizing: border-box;
+        background: rgba(10, 10, 20, 0.85);
+        border-right: 1px solid rgba(255, 255, 255, 0.1);
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      #scene {
+        position: relative;
+        flex: 1;
+        overflow: hidden;
+      }
+      select,
+      button {
+        width: 100%;
+        padding: 8px;
+        border-radius: 4px;
+        border: none;
+        margin-top: 4px;
+        background: rgba(255, 255, 255, 0.1);
+        color: #f7fafc;
+      }
+      button {
+        cursor: pointer;
+      }
+      h2 {
+        margin: 0 0 8px 0;
+        font-size: 1.1rem;
+      }
+      p {
+        margin: 0;
+        font-size: 0.9rem;
+        line-height: 1.4;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="sidebar">
+      <div>
+        <h2>Universal Manipulator</h2>
+        <p>
+          拖动场景中的彩色手柄即可移动、旋转或缩放目标。按住 Shift 进行微调，按住 Ctrl/⌘ 进行大步长拖动。
+        </p>
+      </div>
+      <div>
+        <label for="orientation">Orientation</label>
+        <select id="orientation">
+          <option value="global">Global</option>
+          <option value="local">Local</option>
+          <option value="view">View</option>
+          <option value="enu">ENU</option>
+          <option value="normal">Normal</option>
+          <option value="gimbal">Gimbal</option>
+        </select>
+      </div>
+      <div>
+        <label for="pivot">Pivot</label>
+        <select id="pivot">
+          <option value="origin">Origin</option>
+          <option value="median">Median</option>
+          <option value="cursor">Cursor</option>
+          <option value="individual">Individual</option>
+        </select>
+      </div>
+      <div style="display: flex; gap: 8px;">
+        <button id="undo">Undo</button>
+        <button id="redo">Redo</button>
+      </div>
+      <div>
+        <p>按 Esc 取消当前拖拽。使用方向下拉选项可以体验不同参考系与 Pivot 逻辑。</p>
+      </div>
+    </div>
+    <div id="scene"></div>
+    <script type="module" src="../dist/example/main.js"></script>
+  </body>
+</html>

--- a/example/main.ts
+++ b/example/main.ts
@@ -1,0 +1,147 @@
+import {
+  UniversalManipulator,
+  createPerspectiveCamera,
+  MatrixTransformTarget,
+  Matrix4,
+  Quaternion,
+  Vector3,
+  Orientation,
+  Pivot,
+  updateCameraViewport
+} from '../src/index.js';
+import { projectToScreen } from '../src/core/projection.js';
+import { Matrix3 } from '../src/math/Matrix3.js';
+
+class SceneRenderer {
+  private readonly canvas: HTMLCanvasElement;
+  private readonly context: CanvasRenderingContext2D;
+
+  constructor(private readonly container: HTMLElement, private readonly camera: ReturnType<typeof createPerspectiveCamera>) {
+    this.canvas = document.createElement('canvas');
+    const ctx = this.canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Unable to obtain 2D context.');
+    }
+    this.context = ctx;
+    this.canvas.style.position = 'absolute';
+    this.canvas.style.top = '0';
+    this.canvas.style.left = '0';
+    this.canvas.style.pointerEvents = 'none';
+    this.container.appendChild(this.canvas);
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+  }
+
+  resize(): void {
+    const rect = this.container.getBoundingClientRect();
+    this.canvas.width = rect.width;
+    this.canvas.height = rect.height;
+    updateCameraViewport(this.camera, rect.width, rect.height);
+  }
+
+  render(matrix: Matrix4): void {
+    this.resize();
+    const ctx = this.context;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
+    const origin = matrix.getTranslation(new Vector3());
+    const rotation = matrix.getRotation(new Matrix3());
+    const axes = [
+      { dir: new Vector3(rotation.elements[0], rotation.elements[1], rotation.elements[2]), color: '#ff5555' },
+      { dir: new Vector3(rotation.elements[3], rotation.elements[4], rotation.elements[5]), color: '#55ff55' },
+      { dir: new Vector3(rotation.elements[6], rotation.elements[7], rotation.elements[8]), color: '#5599ff' }
+    ];
+    const axisLength = 10;
+    const originScreen = projectToScreen(this.camera, origin);
+    if (!originScreen) {
+      return;
+    }
+    for (const axis of axes) {
+      const endWorld = Vector3.add(origin, Vector3.multiplyByScalar(axis.dir, axisLength, new Vector3()), new Vector3());
+      const endScreen = projectToScreen(this.camera, endWorld);
+      if (!endScreen) {
+        continue;
+      }
+      ctx.beginPath();
+      ctx.strokeStyle = axis.color;
+      ctx.lineWidth = 2;
+      ctx.moveTo(originScreen.x, originScreen.y);
+      ctx.lineTo(endScreen.x, endScreen.y);
+      ctx.stroke();
+    }
+
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.arc(originScreen.x, originScreen.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function setupControls(manipulator: UniversalManipulator): void {
+  const orientationSelect = document.getElementById('orientation') as HTMLSelectElement;
+  const pivotSelect = document.getElementById('pivot') as HTMLSelectElement;
+  const undoButton = document.getElementById('undo') as HTMLButtonElement;
+  const redoButton = document.getElementById('redo') as HTMLButtonElement;
+
+  orientationSelect.addEventListener('change', () => {
+    manipulator.setOrientation(orientationSelect.value as Orientation);
+  });
+
+  pivotSelect.addEventListener('change', () => {
+    manipulator.setPivot(pivotSelect.value as Pivot);
+  });
+
+  undoButton.addEventListener('click', () => manipulator.undo());
+  redoButton.addEventListener('click', () => manipulator.redo());
+}
+
+function main(): void {
+  const container = document.getElementById('scene') as HTMLElement;
+  const rect = container.getBoundingClientRect();
+  const camera = createPerspectiveCamera({
+    position: new Vector3(30, 30, 30),
+    lookAt: new Vector3(0, 0, 0),
+    viewportWidth: rect.width,
+    viewportHeight: rect.height,
+    aspect: rect.width / rect.height
+  });
+
+  const baseMatrix = Matrix4.fromTranslationRotationScale(
+    new Vector3(0, 0, 0),
+    Quaternion.identity(),
+    new Vector3(1, 1, 1)
+  );
+  const target = new MatrixTransformTarget(baseMatrix);
+
+  const manipulator = new UniversalManipulator(
+    {
+      target,
+      orientation: 'global',
+      pivot: 'origin',
+      enableTranslate: true,
+      enableRotate: true,
+      enableScale: true,
+      snap: {
+        translate: 1,
+        rotate: (5 * Math.PI) / 180,
+        scale: 0.1,
+        fineModifier: 0.2,
+        coarseModifier: 5
+      }
+    },
+    { camera, container }
+  );
+
+  const renderer = new SceneRenderer(container, camera);
+  renderer.render(target.getMatrix());
+
+  setupControls(manipulator);
+
+  const renderLoop = () => {
+    renderer.render(target.getMatrix());
+    requestAnimationFrame(renderLoop);
+  };
+  renderLoop();
+}
+
+window.addEventListener('DOMContentLoaded', main);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cesium-gizmo-demo",
+  "version": "1.0.0",
+  "description": "Universal manipulator for Cesium scenes with example and tests",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "build:watch": "tsc -p tsconfig.build.json --watch",
+    "test": "npm run build && node --test dist/tests",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "cesium",
+    "manipulator",
+    "gizmo",
+    "typescript"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/src/UniversalManipulator.ts
+++ b/src/UniversalManipulator.ts
@@ -1,0 +1,451 @@
+import { CameraState } from './core/CameraState.js';
+import { FrameBuilder } from './core/FrameBuilder.js';
+import { GizmoPicker } from './core/GizmoPicker.js';
+import { GizmoPrimitive } from './core/GizmoPrimitive.js';
+import { HudOverlay } from './core/HudOverlay.js';
+import { ManipulatorController, PointerModifiers } from './core/ManipulatorController.js';
+import { PivotResolver } from './core/PivotResolver.js';
+import { Snapper } from './core/Snapper.js';
+import { TransformSolver } from './core/TransformSolver.js';
+import { GizmoRenderer } from './core/GizmoRenderer.js';
+import { Matrix3 } from './math/Matrix3.js';
+import { Matrix4 } from './math/Matrix4.js';
+import { Quaternion } from './math/Quaternion.js';
+import { Vector2 } from './math/Vector2.js';
+import { Vector3 } from './math/Vector3.js';
+import {
+  Axis,
+  CursorProvider,
+  DragContext,
+  HudDisplayValues,
+  ManipulatorOptions,
+  ManipulatorSizeOptions,
+  Mode,
+  Orientation,
+  Pivot,
+  SnapStepConfig,
+  TransformCommand,
+  TransformDelta,
+  TransformTarget
+} from './types.js';
+
+interface InternalTargetState {
+  target: TransformTarget;
+  initialMatrix: Matrix4;
+  pivot: Vector3;
+}
+
+const DEFAULT_SIZE: ManipulatorSizeOptions = {
+  screenPixelRadius: 120,
+  minScale: 0.5,
+  maxScale: 500
+};
+
+const DEFAULT_SNAP: SnapStepConfig = {
+  translate: 0.5,
+  rotate: (5 * Math.PI) / 180,
+  scale: 0.05,
+  fineModifier: 0.1,
+  coarseModifier: 10
+};
+
+export interface UniversalManipulatorDependencies {
+  camera: CameraState;
+  container: HTMLElement;
+  cursorProvider?: CursorProvider;
+}
+
+export class UniversalManipulator {
+  show = true;
+  private orientation: Orientation;
+  private pivotMode: Pivot;
+  private readonly primitive: GizmoPrimitive;
+  private readonly picker: GizmoPicker;
+  private readonly snapper: Snapper;
+  private readonly solver: TransformSolver;
+  private readonly frameBuilder: FrameBuilder;
+  private readonly pivotResolver: PivotResolver;
+  private readonly controller: ManipulatorController;
+  private readonly hud: HudOverlay;
+  private readonly renderer: GizmoRenderer;
+  private readonly container: HTMLElement;
+  private readonly camera: CameraState;
+  private readonly enabledModes: Record<Mode, boolean> = {
+    translate: true,
+    rotate: true,
+    scale: true
+  };
+  private targets: TransformTarget[] = [];
+  private frameState: ReturnType<FrameBuilder['build']> | undefined;
+  private sizeOptions: ManipulatorSizeOptions = { ...DEFAULT_SIZE };
+  private pointerId: number | undefined;
+  private pointerDown = false;
+  private internalStates = new Map<string, InternalTargetState>();
+  private undoStack: TransformCommand[] = [];
+  private redoStack: TransformCommand[] = [];
+  private activeHandleId: string | undefined;
+
+  constructor(options: ManipulatorOptions, deps: UniversalManipulatorDependencies) {
+    this.orientation = options.orientation ?? 'global';
+    this.pivotMode = options.pivot ?? 'origin';
+    this.container = deps.container;
+    this.camera = deps.camera;
+    this.primitive = new GizmoPrimitive();
+    this.picker = new GizmoPicker(this.primitive);
+    this.snapper = new Snapper(options.snap ?? DEFAULT_SNAP);
+    this.solver = new TransformSolver(this.snapper);
+    this.frameBuilder = new FrameBuilder();
+    this.pivotResolver = new PivotResolver(deps.cursorProvider);
+    this.controller = new ManipulatorController(this.picker, this.solver, {
+      picker: this.picker,
+      solver: this.solver,
+      camera: this.camera,
+      callbacks: {
+        onHover: (pick) => this.handleHover(pick?.handleId),
+        onDragStart: (context) => this.handleDragStart(context),
+        onDrag: (context, delta, snapped) => this.handleDrag(context, delta, snapped),
+        onDragEnd: (context, delta, committed) => this.handleDragEnd(context, delta, committed)
+      }
+    });
+    this.hud = new HudOverlay(this.container);
+    this.renderer = new GizmoRenderer(this.container, this.primitive);
+    this.setSize(options.size ?? DEFAULT_SIZE);
+    this.setTarget(options.target);
+    this.updateModeVisibility(options);
+    this.attachEventListeners();
+    if (options.show === false) {
+      this.setShow(false);
+    }
+  }
+
+  setTarget(target: TransformTarget | TransformTarget[] | undefined): void {
+    this.targets = !target ? [] : Array.isArray(target) ? target : [target];
+    this.updateManipulator();
+  }
+
+  setOrientation(orientation: Orientation): void {
+    this.orientation = orientation;
+    this.updateManipulator();
+  }
+
+  setPivot(pivot: Pivot): void {
+    this.pivotMode = pivot;
+    this.updateManipulator();
+  }
+
+  enable(options: Partial<Record<Mode, boolean>>): void {
+    for (const key of Object.keys(options) as Mode[]) {
+      const value = options[key];
+      if (typeof value === 'boolean') {
+        this.enabledModes[key] = value;
+        this.primitive.setModeVisibility(key, value);
+      }
+    }
+  }
+
+  setSnap(stepConfig?: SnapStepConfig): void {
+    this.snapper.setConfig(stepConfig ?? DEFAULT_SNAP);
+  }
+
+  setSize(size: ManipulatorSizeOptions): void {
+    this.sizeOptions = { ...DEFAULT_SIZE, ...size };
+    this.updateManipulator();
+  }
+
+  setShow(visible: boolean): void {
+    this.show = visible;
+    this.primitive.show = visible;
+    this.hud.setVisible(visible);
+    this.renderer.render(this.camera);
+  }
+
+  undo(): void {
+    const command = this.undoStack.pop();
+    if (!command) {
+      return;
+    }
+    this.applyMatrixToTarget(command.id, command.before);
+    this.redoStack.push(command);
+    this.updateManipulator();
+  }
+
+  redo(): void {
+    const command = this.redoStack.pop();
+    if (!command) {
+      return;
+    }
+    this.applyMatrixToTarget(command.id, command.after);
+    this.undoStack.push(command);
+    this.updateManipulator();
+  }
+
+  destroy(): void {
+    this.container.removeEventListener('pointerdown', this.onPointerDown);
+    this.container.removeEventListener('pointermove', this.onPointerMove);
+    window.removeEventListener('pointerup', this.onPointerUp);
+    window.removeEventListener('keydown', this.onKeyDown);
+    this.hud.destroy();
+    this.renderer.destroy();
+  }
+
+  private updateModeVisibility(options: ManipulatorOptions): void {
+    if (options.enableTranslate === false) {
+      this.enabledModes.translate = false;
+      this.primitive.setModeVisibility('translate', false);
+    }
+    if (options.enableRotate === false) {
+      this.enabledModes.rotate = false;
+      this.primitive.setModeVisibility('rotate', false);
+    }
+    if (options.enableScale === false) {
+      this.enabledModes.scale = false;
+      this.primitive.setModeVisibility('scale', false);
+    }
+  }
+
+  private attachEventListeners(): void {
+    this.container.addEventListener('pointerdown', this.onPointerDown);
+    this.container.addEventListener('pointermove', this.onPointerMove);
+    window.addEventListener('pointerup', this.onPointerUp);
+    window.addEventListener('keydown', this.onKeyDown);
+  }
+
+  private onPointerDown = (event: PointerEvent): void => {
+    if (!this.show || !this.frameState) {
+      return;
+    }
+    this.pointerId = event.pointerId;
+    this.pointerDown = true;
+    this.container.setPointerCapture(event.pointerId);
+    const position = this.toLocalPosition(event);
+    this.controller.setFrame(this.frameState);
+    this.controller.handlePointerDown(position, this.toModifiers(event));
+    event.preventDefault();
+  };
+
+  private onPointerMove = (event: PointerEvent): void => {
+    if (!this.show || !this.frameState) {
+      return;
+    }
+    const position = this.toLocalPosition(event);
+    this.controller.setFrame(this.frameState);
+    this.controller.handlePointerMove(position, this.toModifiers(event));
+  };
+
+  private onPointerUp = (event: PointerEvent): void => {
+    if (!this.pointerDown) {
+      return;
+    }
+    const position = this.toLocalPosition(event);
+    this.controller.handlePointerUp(position, this.toModifiers(event));
+    if (this.pointerId !== undefined) {
+      try {
+        this.container.releasePointerCapture(this.pointerId);
+      } catch (error) {
+        // ignore
+      }
+    }
+    this.pointerDown = false;
+  };
+
+  private onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      this.controller.cancelDrag();
+    } else if (event.key === 'z' && (event.ctrlKey || event.metaKey)) {
+      this.undo();
+    } else if (event.key === 'y' && (event.ctrlKey || event.metaKey)) {
+      this.redo();
+    }
+  };
+
+  private handleHover(handleId: string | undefined): void {
+    const states = this.primitive.handles.map((handle) => ({
+      id: handle.id,
+      mode: handle.mode,
+      axis: handle.axis,
+      active: handle.id === this.activeHandleId,
+      highlighted: handle.id === handleId
+    }));
+    this.primitive.setVisualStates(states);
+  }
+
+  private handleDragStart(context: DragContext): void {
+    if (!this.frameState) {
+      return;
+    }
+    this.internalStates.clear();
+    this.activeHandleId = context.handleId;
+    const perTargetPivot = this.pivotResolver.resolvePerTargetPivot(this.pivotMode, this.targets, context.pivotWorld);
+    for (const target of this.targets) {
+      const before = target.getMatrix();
+      const pivot = perTargetPivot.get(target.id) ?? context.pivotWorld;
+      this.internalStates.set(target.id, {
+        target,
+        initialMatrix: before,
+        pivot: pivot
+      });
+    }
+    this.handleHover(context.handleId);
+  }
+
+  private handleDrag(context: DragContext, delta: TransformDelta, snapped: boolean): void {
+    if (!this.frameState) {
+      return;
+    }
+    for (const state of this.internalStates.values()) {
+      const matrix = this.applyDelta(state.initialMatrix, delta, state.pivot, this.frameState);
+      state.target.setMatrix(matrix);
+    }
+    context.currentDelta = delta;
+    const hudValues = this.buildHudValues(context, delta, snapped);
+    this.hud.update(hudValues);
+    this.renderer.render(this.camera);
+  }
+
+  private handleDragEnd(context: DragContext, delta: TransformDelta, committed: boolean): void {
+    if (committed) {
+      for (const state of this.internalStates.values()) {
+        const after = state.target.getMatrix();
+        this.undoStack.push({ id: state.target.id, before: state.initialMatrix, after });
+      }
+      this.redoStack = [];
+    } else {
+      for (const state of this.internalStates.values()) {
+        state.target.setMatrix(state.initialMatrix);
+      }
+    }
+    this.internalStates.clear();
+    this.activeHandleId = undefined;
+    this.handleHover(undefined);
+    this.updateManipulator();
+  }
+
+  private buildHudValues(context: DragContext, delta: TransformDelta, snapped: boolean): HudDisplayValues {
+    const frame = context.frame;
+    const translationLocal = new Vector3(
+      Vector3.dot(delta.translation, frame.axes.x),
+      Vector3.dot(delta.translation, frame.axes.y),
+      Vector3.dot(delta.translation, frame.axes.z)
+    );
+    const rotationEuler = delta.rotation.toEuler(new Vector3());
+    const axisLabel = context.axis ? context.axis.toUpperCase() : context.planeAxis ? context.planeAxis.join('').toUpperCase() : 'FREE';
+    return {
+      mode: context.mode,
+      axisLabel,
+      deltaTranslation: translationLocal,
+      deltaRotation: rotationEuler,
+      deltaScale: delta.scale,
+      snapped
+    };
+  }
+
+  private applyDelta(baseMatrix: Matrix4, delta: TransformDelta, pivot: Vector3, frame: ReturnType<FrameBuilder['build']>): Matrix4 {
+    const translationMatrix = this.translationMatrix(delta.translation);
+    const pivotMatrix = this.translationMatrix(pivot);
+    const pivotInverseMatrix = this.translationMatrix(Vector3.multiplyByScalar(pivot, -1, new Vector3()));
+    const rotationMatrix = this.rotationMatrix(delta.rotation);
+    const scaleMatrix = this.scaleMatrix(delta.scale, frame);
+
+    const combined = multiplyMatrices(
+      translationMatrix,
+      multiplyMatrices(
+        pivotMatrix,
+        multiplyMatrices(
+          rotationMatrix,
+          multiplyMatrices(scaleMatrix, multiplyMatrices(pivotInverseMatrix, baseMatrix))
+        )
+      )
+    );
+    return combined;
+  }
+
+  private translationMatrix(offset: Vector3): Matrix4 {
+    const matrix = Matrix4.identity();
+    const e = matrix.elements;
+    e[12] = offset.x;
+    e[13] = offset.y;
+    e[14] = offset.z;
+    return matrix;
+  }
+
+  private rotationMatrix(quaternion: Quaternion): Matrix4 {
+    const matrix3 = quaternion.toMatrix3(new Matrix3());
+    const matrix = Matrix4.identity();
+    const e = matrix.elements;
+    const m = matrix3.elements;
+    e[0] = m[0]; e[1] = m[1]; e[2] = m[2];
+    e[4] = m[3]; e[5] = m[4]; e[6] = m[5];
+    e[8] = m[6]; e[9] = m[7]; e[10] = m[8];
+    return matrix;
+  }
+
+  private scaleMatrix(scale: Vector3, frame: ReturnType<FrameBuilder['build']>): Matrix4 {
+    if (Math.abs(scale.x - 1) < 1e-6 && Math.abs(scale.y - 1) < 1e-6 && Math.abs(scale.z - 1) < 1e-6) {
+      return Matrix4.identity();
+    }
+    const scaleMatrix = Matrix4.identity();
+    const e = scaleMatrix.elements;
+    e[0] = scale.x;
+    e[5] = scale.y;
+    e[10] = scale.z;
+    const worldScale = frame.matrix.clone(new Matrix4()).multiply(scaleMatrix).multiply(frame.inverse);
+    return worldScale;
+  }
+
+  private applyMatrixToTarget(targetId: string, matrix: Matrix4): void {
+    const target = this.targets.find((t) => t.id === targetId);
+    if (target) {
+      target.setMatrix(matrix);
+    }
+  }
+
+  private updateManipulator(): void {
+    if (!this.show || this.targets.length === 0) {
+      this.primitive.show = false;
+      return;
+    }
+    const pivot = this.pivotResolver.resolveManipulatorPivot(this.pivotMode, this.targets);
+    const frame = this.frameBuilder.build({
+      orientation: this.orientation,
+      pivot,
+      targets: this.targets,
+      camera: this.camera
+    });
+    this.frameState = frame;
+    const scale = this.computeScreenScale(pivot);
+    this.primitive.update(frame, this.camera, scale);
+    this.controller.setFrame(frame);
+    this.primitive.show = true;
+    this.renderer.render(this.camera);
+  }
+
+  private computeScreenScale(pivot: Vector3): number {
+    const distance = Vector3.distance(this.camera.position, pivot);
+    const worldHeight = 2 * distance * Math.tan(this.camera.fov / 2);
+    const pixelsPerMeter = this.camera.viewportHeight / Math.max(worldHeight, 1e-6);
+    const desired = this.sizeOptions.screenPixelRadius / Math.max(pixelsPerMeter, 1e-6);
+    return clamp(desired, this.sizeOptions.minScale, this.sizeOptions.maxScale);
+  }
+
+  private toLocalPosition(event: PointerEvent): Vector2 {
+    const rect = this.container.getBoundingClientRect();
+    return new Vector2(event.clientX - rect.left, event.clientY - rect.top);
+  }
+
+  private toModifiers(event: PointerEvent | KeyboardEvent): PointerModifiers {
+    return {
+      shiftKey: event.shiftKey,
+      ctrlKey: event.ctrlKey,
+      altKey: event.altKey ?? false,
+      metaKey: event.metaKey ?? false
+    };
+  }
+}
+
+function multiplyMatrices(a: Matrix4, b: Matrix4): Matrix4 {
+  return a.multiply(b, new Matrix4());
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/core/CameraState.ts
+++ b/src/core/CameraState.ts
@@ -1,0 +1,104 @@
+import { Matrix4 } from '../math/Matrix4.js';
+import { Vector3 } from '../math/Vector3.js';
+
+export interface CameraState {
+  position: Vector3;
+  direction: Vector3;
+  up: Vector3;
+  right: Vector3;
+  fov: number;
+  aspect: number;
+  near: number;
+  far: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  viewMatrix: Matrix4;
+  projectionMatrix: Matrix4;
+  viewProjectionMatrix: Matrix4;
+}
+
+export interface PerspectiveCameraOptions {
+  position: Vector3;
+  lookAt: Vector3;
+  up?: Vector3;
+  fov?: number;
+  aspect?: number;
+  near?: number;
+  far?: number;
+  viewportWidth?: number;
+  viewportHeight?: number;
+}
+
+export function createPerspectiveCamera(options: PerspectiveCameraOptions): CameraState {
+  const {
+    position,
+    lookAt,
+    up = new Vector3(0, 0, 1),
+    fov = (45 * Math.PI) / 180,
+    aspect = 1,
+    near = 0.1,
+    far = 10000,
+    viewportWidth = 800,
+    viewportHeight = 600
+  } = options;
+
+  const direction = Vector3.normalize(Vector3.subtract(lookAt, position, new Vector3()));
+  const right = Vector3.normalize(Vector3.cross(direction, up, new Vector3()));
+  const correctedUp = Vector3.normalize(Vector3.cross(right, direction, new Vector3()));
+
+  const viewMatrix = buildViewMatrix(position, direction, correctedUp, right);
+  const projectionMatrix = buildPerspectiveMatrix(fov, aspect, near, far);
+  const viewProjectionMatrix = projectionMatrix.clone(new Matrix4()).multiply(viewMatrix);
+
+  return {
+    position,
+    direction,
+    up: correctedUp,
+    right,
+    fov,
+    aspect,
+    near,
+    far,
+    viewportWidth,
+    viewportHeight,
+    viewMatrix,
+    projectionMatrix,
+    viewProjectionMatrix
+  };
+}
+
+function buildViewMatrix(position: Vector3, direction: Vector3, up: Vector3, right: Vector3): Matrix4 {
+  const dir = Vector3.normalize(direction, new Vector3());
+  const negDir = Vector3.multiplyByScalar(dir, -1, new Vector3());
+  const mat = new Matrix4();
+  const e = mat.elements;
+  e[0] = right.x; e[4] = right.y; e[8] = right.z; e[12] = -Vector3.dot(right, position);
+  e[1] = up.x; e[5] = up.y; e[9] = up.z; e[13] = -Vector3.dot(up, position);
+  e[2] = negDir.x; e[6] = negDir.y; e[10] = negDir.z; e[14] = -Vector3.dot(negDir, position);
+  e[3] = 0; e[7] = 0; e[11] = 0; e[15] = 1;
+  return mat;
+}
+
+function buildPerspectiveMatrix(fov: number, aspect: number, near: number, far: number): Matrix4 {
+  const f = 1.0 / Math.tan(fov / 2);
+  const rangeInv = 1 / (near - far);
+  const mat = new Matrix4();
+  const e = mat.elements;
+  e[0] = f / aspect;
+  e[5] = f;
+  e[10] = (far + near) * rangeInv;
+  e[11] = -1;
+  e[14] = 2 * far * near * rangeInv;
+  e[15] = 0;
+  e[1] = e[2] = e[3] = e[4] = e[6] = e[7] = e[8] = e[9] = e[12] = e[13] = 0;
+  return mat;
+}
+
+export function updateCameraViewport(camera: CameraState, width: number, height: number): void {
+  camera.viewportWidth = width;
+  camera.viewportHeight = height;
+  camera.aspect = width / Math.max(height, 1);
+  const projection = buildPerspectiveMatrix(camera.fov, camera.aspect, camera.near, camera.far);
+  camera.projectionMatrix = projection;
+  camera.viewProjectionMatrix = projection.clone(new Matrix4()).multiply(camera.viewMatrix);
+}

--- a/src/core/FrameBuilder.ts
+++ b/src/core/FrameBuilder.ts
@@ -1,0 +1,124 @@
+import { Matrix3 } from '../math/Matrix3.js';
+import { Matrix4 } from '../math/Matrix4.js';
+import { Quaternion } from '../math/Quaternion.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Orientation, FrameState, TransformTarget } from '../types.js';
+import { enuAxes } from '../utils/Geodesy.js';
+import { CameraState } from './CameraState.js';
+
+const scratchMatrix = new Matrix4();
+
+export interface FrameBuilderOptions {
+  orientation: Orientation;
+  pivot: Vector3;
+  targets: TransformTarget[];
+  camera: CameraState;
+  normal?: Vector3;
+}
+
+export class FrameBuilder {
+  build(options: FrameBuilderOptions): FrameState {
+    const axes = this.buildAxes(options);
+    const matrix = Matrix4.fromColumns(axes.x, axes.y, axes.z, options.pivot, new Matrix4());
+    const inverse = matrix.clone(new Matrix4()).invert();
+    return { origin: options.pivot, axes, matrix, inverse };
+  }
+
+  private buildAxes({ orientation, targets, camera, normal, pivot }: FrameBuilderOptions): FrameState['axes'] {
+    switch (orientation) {
+      case 'global':
+        return {
+          x: new Vector3(1, 0, 0),
+          y: new Vector3(0, 1, 0),
+          z: new Vector3(0, 0, 1)
+        };
+      case 'local':
+        return this.fromTargetOrientation(targets[0]);
+      case 'view':
+        return this.fromView(camera);
+      case 'enu':
+        return this.fromEnu(pivot);
+      case 'normal':
+        return this.fromNormal(targets[0], normal, camera);
+      case 'gimbal':
+        return this.fromGimbal(targets[0], camera);
+      default:
+        return {
+          x: new Vector3(1, 0, 0),
+          y: new Vector3(0, 1, 0),
+          z: new Vector3(0, 0, 1)
+        };
+    }
+  }
+
+  private fromTargetOrientation(target: TransformTarget): FrameState['axes'] {
+    const matrix = target.getMatrix();
+    const rotation = matrix.getRotation(new Matrix3());
+    const e = rotation.elements;
+    return {
+      x: Vector3.normalize(new Vector3(e[0], e[1], e[2])),
+      y: Vector3.normalize(new Vector3(e[3], e[4], e[5])),
+      z: Vector3.normalize(new Vector3(e[6], e[7], e[8]))
+    };
+  }
+
+  private fromView(camera: CameraState): FrameState['axes'] {
+    return {
+      x: Vector3.clone(camera.right),
+      y: Vector3.clone(camera.up),
+      z: Vector3.clone(camera.direction)
+    };
+  }
+
+  private fromEnu(pivot: Vector3): FrameState['axes'] {
+    const { east, north, up } = enuAxes(pivot);
+    return {
+      x: east,
+      y: north,
+      z: up
+    };
+  }
+
+  private fromNormal(target: TransformTarget, normal: Vector3 | undefined, camera: CameraState): FrameState['axes'] {
+    const baseAxes = this.fromTargetOrientation(target);
+    const referenceNormal = normal ? Vector3.normalize(normal, new Vector3()) : baseAxes.z;
+    const viewDir = camera.direction;
+    const tangent = Vector3.normalize(Vector3.cross(referenceNormal, viewDir, new Vector3()));
+    if (Vector3.magnitudeSquared(tangent) < 1e-6) {
+      // fallback to base axes to avoid degeneracy
+      return baseAxes;
+    }
+    const bitangent = Vector3.normalize(Vector3.cross(referenceNormal, tangent, new Vector3()));
+    return {
+      x: tangent,
+      y: bitangent,
+      z: referenceNormal
+    };
+  }
+
+  private fromGimbal(target: TransformTarget, camera: CameraState): FrameState['axes'] {
+    const matrix = target.getMatrix();
+    const orientation = Quaternion.fromRotationMatrix(matrix.getRotation(new Matrix3()));
+    const euler = orientation.toEuler(new Vector3());
+    const yawOnly = Quaternion.fromEuler(euler.z, 0, 0); // yaw around up axis
+    const yawAxes = this.axesFromQuaternion(yawOnly);
+    // Align roll axis with camera up projection to reduce gimbal lock
+    const projectedUp = Vector3.projectOnPlane(camera.up, yawAxes.z, new Vector3());
+    if (Vector3.magnitudeSquared(projectedUp) > 1e-6) {
+      const xAxis = Vector3.normalize(Vector3.cross(projectedUp, yawAxes.z, new Vector3()));
+      const yAxis = Vector3.normalize(Vector3.cross(yawAxes.z, xAxis, new Vector3()));
+      return { x: xAxis, y: yAxis, z: yawAxes.z };
+    }
+    return yawAxes;
+  }
+
+  private axesFromQuaternion(q: Quaternion): FrameState['axes'] {
+    const matrix = q.toMatrix3(new Matrix3());
+    const e = matrix.elements;
+    return {
+      x: Vector3.normalize(new Vector3(e[0], e[1], e[2])),
+      y: Vector3.normalize(new Vector3(e[3], e[4], e[5])),
+      z: Vector3.normalize(new Vector3(e[6], e[7], e[8]))
+    };
+  }
+}

--- a/src/core/GizmoPicker.ts
+++ b/src/core/GizmoPicker.ts
@@ -1,0 +1,154 @@
+import { CameraState } from './CameraState.js';
+import { GizmoPrimitive, HandleGeometry } from './GizmoPrimitive.js';
+import { PickResult } from '../types.js';
+import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
+import { projectToScreen, ScreenPoint } from './projection.js';
+
+const AXIS_PICK_THRESHOLD = 12;
+const PLANE_PICK_THRESHOLD = 20;
+const RING_PICK_THRESHOLD = 15;
+
+export class GizmoPicker {
+  constructor(private readonly primitive: GizmoPrimitive) {}
+
+  pick(camera: CameraState, pointer: Vector2): PickResult | undefined {
+    if (!this.primitive.show) {
+      return undefined;
+    }
+    let best: PickResult | undefined;
+    for (const handle of this.primitive.handles) {
+      if (!handle.visible) {
+        continue;
+      }
+      const result = this.testHandle(camera, handle, pointer);
+      if (!result) {
+        continue;
+      }
+      if (!best || result.distance < best.distance) {
+        best = result;
+      }
+    }
+    return best;
+  }
+
+  private testHandle(camera: CameraState, handle: HandleGeometry, pointer: Vector2): PickResult | undefined {
+    switch (handle.type) {
+      case 'axis':
+        return this.testAxisHandle(camera, handle, pointer);
+      case 'plane':
+        return this.testPlaneHandle(camera, handle, pointer);
+      case 'ring':
+        return this.testRingHandle(camera, handle, pointer);
+      case 'center':
+        return this.testCenterHandle(camera, handle, pointer);
+      default:
+        return undefined;
+    }
+  }
+
+  private testAxisHandle(camera: CameraState, handle: HandleGeometry, pointer: Vector2): PickResult | undefined {
+    if (!handle.end) {
+      return undefined;
+    }
+    const start = projectToScreen(camera, handle.start);
+    const end = projectToScreen(camera, handle.end);
+    if (!start || !end) {
+      return undefined;
+    }
+    const distance = distancePointToSegment(pointer, start, end);
+    if (distance > AXIS_PICK_THRESHOLD) {
+      return undefined;
+    }
+    return {
+      handleId: handle.id,
+      mode: handle.mode,
+      axis: handle.axis,
+      distance,
+      screenPosition: { x: start.x, y: start.y }
+    };
+  }
+
+  private testPlaneHandle(camera: CameraState, handle: HandleGeometry, pointer: Vector2): PickResult | undefined {
+    const center = projectToScreen(camera, handle.start);
+    if (!center) {
+      return undefined;
+    }
+    const radius = this.primitive.getScale() * 25;
+    const distance = Math.hypot(pointer.x - center.x, pointer.y - center.y);
+    if (distance > radius + PLANE_PICK_THRESHOLD) {
+      return undefined;
+    }
+    return {
+      handleId: handle.id,
+      mode: handle.mode,
+      planeAxis: handle.planeAxis,
+      distance,
+      screenPosition: { x: center.x, y: center.y }
+    };
+  }
+
+  private testRingHandle(camera: CameraState, handle: HandleGeometry, pointer: Vector2): PickResult | undefined {
+    if (!handle.normal || !handle.radius) {
+      return undefined;
+    }
+    const center = projectToScreen(camera, handle.start);
+    if (!center) {
+      return undefined;
+    }
+    const ringPointWorld = Vector3.add(handle.start, Vector3.multiplyByScalar(handle.normal, this.primitive.getScale() * handle.radius, new Vector3()), new Vector3());
+    const ringPointScreen = projectToScreen(camera, ringPointWorld);
+    if (!ringPointScreen) {
+      return undefined;
+    }
+    const radius = Math.hypot(ringPointScreen.x - center.x, ringPointScreen.y - center.y);
+    const distance = Math.abs(Math.hypot(pointer.x - center.x, pointer.y - center.y) - radius);
+    if (distance > RING_PICK_THRESHOLD) {
+      return undefined;
+    }
+    return {
+      handleId: handle.id,
+      mode: handle.mode,
+      axis: handle.axis,
+      distance,
+      screenPosition: { x: center.x, y: center.y }
+    };
+  }
+
+  private testCenterHandle(camera: CameraState, handle: HandleGeometry, pointer: Vector2): PickResult | undefined {
+    const center = projectToScreen(camera, handle.start);
+    if (!center) {
+      return undefined;
+    }
+    const radius = this.primitive.getScale() * 15;
+    const distance = Math.hypot(pointer.x - center.x, pointer.y - center.y);
+    if (distance > radius) {
+      return undefined;
+    }
+    return {
+      handleId: handle.id,
+      mode: handle.mode,
+      distance,
+      screenPosition: { x: center.x, y: center.y }
+    };
+  }
+}
+
+function distancePointToSegment(point: Vector2, start: ScreenPoint, end: ScreenPoint): number {
+  const vx = end.x - start.x;
+  const vy = end.y - start.y;
+  const wx = point.x - start.x;
+  const wy = point.y - start.y;
+  const c1 = vx * wx + vy * wy;
+  if (c1 <= 0) {
+    return Math.hypot(point.x - start.x, point.y - start.y);
+  }
+  const c2 = vx * vx + vy * vy;
+  if (c2 <= c1) {
+    return Math.hypot(point.x - end.x, point.y - end.y);
+  }
+  const b = c1 / c2;
+  const pbx = start.x + b * vx;
+  const pby = start.y + b * vy;
+  return Math.hypot(point.x - pbx, point.y - pby);
+}

--- a/src/core/GizmoPrimitive.ts
+++ b/src/core/GizmoPrimitive.ts
@@ -1,0 +1,201 @@
+import { CameraState } from './CameraState.js';
+import { Axis, FrameState, HandleVisualState, Mode } from '../types.js';
+import { Vector3 } from '../math/Vector3.js';
+
+export type HandleType = 'axis' | 'plane' | 'ring' | 'center';
+
+export interface HandleGeometry {
+  id: string;
+  mode: Mode;
+  axis?: Axis;
+  planeAxis?: [Axis, Axis];
+  type: HandleType;
+  color: string;
+  start: Vector3;
+  end?: Vector3;
+  normal?: Vector3;
+  radius?: number;
+  active: boolean;
+  highlighted: boolean;
+  visible: boolean;
+}
+
+const AXIS_COLORS: Record<Axis, string> = {
+  x: '#ff5555',
+  y: '#55ff55',
+  z: '#5599ff'
+};
+
+const MODE_ID_PREFIX: Record<Mode, string> = {
+  translate: 'T',
+  rotate: 'R',
+  scale: 'S'
+};
+
+export class GizmoPrimitive {
+  readonly handles: HandleGeometry[] = [];
+  show = true;
+  private scale = 1.0;
+
+  constructor() {
+    this.createDefaultHandles();
+  }
+
+  private createDefaultHandles(): void {
+    for (const axis of ['x', 'y', 'z'] as Axis[]) {
+      this.handles.push({
+        id: `${MODE_ID_PREFIX.translate}-${axis}`,
+        mode: 'translate',
+        axis,
+        type: 'axis',
+        color: AXIS_COLORS[axis],
+        start: new Vector3(),
+        end: new Vector3(1, 0, 0),
+        active: false,
+        highlighted: false,
+        visible: true
+      });
+    }
+    for (const axis of ['x', 'y', 'z'] as Axis[]) {
+      this.handles.push({
+        id: `${MODE_ID_PREFIX.scale}-${axis}`,
+        mode: 'scale',
+        axis,
+        type: 'axis',
+        color: AXIS_COLORS[axis],
+        start: new Vector3(),
+        end: new Vector3(1, 0, 0),
+        active: false,
+        highlighted: false,
+        visible: true
+      });
+    }
+    const planes: Array<[Axis, Axis]> = [
+      ['x', 'y'],
+      ['y', 'z'],
+      ['x', 'z']
+    ];
+    for (const planeAxis of planes) {
+      this.handles.push({
+        id: `${MODE_ID_PREFIX.translate}-plane-${planeAxis.join('')}`,
+        mode: 'translate',
+        planeAxis,
+        type: 'plane',
+        color: '#ffff55',
+        start: new Vector3(),
+        normal: new Vector3(0, 0, 1),
+        active: false,
+        highlighted: false,
+        visible: true
+      });
+    }
+    for (const axis of ['x', 'y', 'z'] as Axis[]) {
+      this.handles.push({
+        id: `${MODE_ID_PREFIX.rotate}-${axis}`,
+        mode: 'rotate',
+        axis,
+        type: 'ring',
+        color: AXIS_COLORS[axis],
+        start: new Vector3(),
+        normal: new Vector3(),
+        radius: 1,
+        active: false,
+        highlighted: false,
+        visible: true
+      });
+    }
+    this.handles.push({
+      id: `${MODE_ID_PREFIX.rotate}-view`,
+      mode: 'rotate',
+      type: 'ring',
+      color: '#ffffff',
+      start: new Vector3(),
+      normal: new Vector3(),
+      radius: 1.2,
+      active: false,
+      highlighted: false,
+      visible: true
+    });
+    this.handles.push({
+      id: `${MODE_ID_PREFIX.scale}-uniform`,
+      mode: 'scale',
+      type: 'center',
+      color: '#ffffff',
+      start: new Vector3(),
+      radius: 0.2,
+      active: false,
+      highlighted: false,
+      visible: true
+    });
+  }
+
+  update(frame: FrameState, camera: CameraState, scale: number): void {
+    this.scale = scale;
+    for (const handle of this.handles) {
+      if (!handle.visible) {
+        continue;
+      }
+      handle.start = Vector3.clone(frame.origin, handle.start);
+      switch (handle.type) {
+        case 'axis':
+          handle.end = this.computeAxisEnd(handle, frame);
+          break;
+        case 'plane':
+          handle.normal = this.computePlaneNormal(handle, frame);
+          break;
+        case 'ring':
+          handle.normal = this.computeRingNormal(handle, frame, camera);
+          break;
+        case 'center':
+          handle.start = Vector3.clone(frame.origin, handle.start);
+          break;
+      }
+    }
+  }
+
+  getScale(): number {
+    return this.scale;
+  }
+
+  setVisualStates(states: HandleVisualState[]): void {
+    for (const state of states) {
+      const handle = this.handles.find((h) => h.id === state.id);
+      if (handle) {
+        handle.active = state.active;
+        handle.highlighted = state.highlighted;
+      }
+    }
+  }
+
+  setModeVisibility(mode: Mode, visible: boolean): void {
+    for (const handle of this.handles) {
+      if (handle.mode === mode) {
+        handle.visible = visible;
+      }
+    }
+  }
+
+  private computeAxisEnd(handle: HandleGeometry, frame: FrameState): Vector3 {
+    if (!handle.axis) {
+      return new Vector3();
+    }
+    const axisVector = Vector3.multiplyByScalar(frame.axes[handle.axis], this.scale, new Vector3());
+    return Vector3.add(frame.origin, axisVector, new Vector3());
+  }
+
+  private computePlaneNormal(handle: HandleGeometry, frame: FrameState): Vector3 {
+    if (!handle.planeAxis) {
+      return new Vector3(0, 0, 1);
+    }
+    const axisA = frame.axes[handle.planeAxis[0]];
+    const axisB = frame.axes[handle.planeAxis[1]];
+    return Vector3.normalize(Vector3.cross(axisA, axisB, new Vector3()));
+  }
+
+  private computeRingNormal(handle: HandleGeometry, frame: FrameState, camera: CameraState): Vector3 {
+    if (!handle.axis) {
+      return Vector3.clone(camera.direction);
+    }
+    return frame.axes[handle.axis];
+  }
+}

--- a/src/core/GizmoRenderer.ts
+++ b/src/core/GizmoRenderer.ts
@@ -1,0 +1,134 @@
+import { CameraState } from './CameraState.js';
+import { GizmoPrimitive, HandleGeometry } from './GizmoPrimitive.js';
+import { projectToScreen } from './projection.js';
+import { Vector3 } from '../math/Vector3.js';
+
+export class GizmoRenderer {
+  private readonly canvas: HTMLCanvasElement;
+  private readonly context: CanvasRenderingContext2D;
+  private readonly resizeHandler: () => void;
+
+  constructor(private readonly container: HTMLElement, private readonly primitive: GizmoPrimitive) {
+    this.canvas = document.createElement('canvas');
+    const ctx = this.canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Failed to acquire 2D context for gizmo renderer.');
+    }
+    this.context = ctx;
+    this.canvas.style.position = 'absolute';
+    this.canvas.style.top = '0';
+    this.canvas.style.left = '0';
+    this.canvas.style.pointerEvents = 'none';
+    this.container.appendChild(this.canvas);
+    this.resize();
+    this.resizeHandler = () => this.resize();
+    window.addEventListener('resize', this.resizeHandler);
+  }
+
+  render(camera: CameraState): void {
+    this.resize();
+    const ctx = this.context;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    if (!this.primitive.show) {
+      return;
+    }
+    for (const handle of this.primitive.handles) {
+      if (!handle.visible) {
+        continue;
+      }
+      ctx.save();
+      ctx.strokeStyle = handle.active ? '#ffffff' : handle.color;
+      ctx.lineWidth = handle.active ? 3 : 2;
+      ctx.globalAlpha = handle.highlighted ? 1 : 0.8;
+      switch (handle.type) {
+        case 'axis':
+          this.drawAxis(camera, handle);
+          break;
+        case 'plane':
+          this.drawPlane(camera, handle);
+          break;
+        case 'ring':
+          this.drawRing(camera, handle);
+          break;
+        case 'center':
+          this.drawCenter(camera, handle);
+          break;
+      }
+      ctx.restore();
+    }
+  }
+
+  resize(): void {
+    const rect = this.container.getBoundingClientRect();
+    if (this.canvas.width !== rect.width || this.canvas.height !== rect.height) {
+      this.canvas.width = rect.width;
+      this.canvas.height = rect.height;
+    }
+  }
+
+  destroy(): void {
+    window.removeEventListener('resize', this.resizeHandler);
+    this.canvas.remove();
+  }
+
+  private drawAxis(camera: CameraState, handle: HandleGeometry): void {
+    if (!handle.end) {
+      return;
+    }
+    const start = projectToScreen(camera, handle.start);
+    const end = projectToScreen(camera, handle.end);
+    if (!start || !end) {
+      return;
+    }
+    this.context.beginPath();
+    this.context.moveTo(start.x, start.y);
+    this.context.lineTo(end.x, end.y);
+    this.context.stroke();
+  }
+
+  private drawPlane(camera: CameraState, handle: HandleGeometry): void {
+    const center = projectToScreen(camera, handle.start);
+    if (!center) {
+      return;
+    }
+    const radius = this.primitive.getScale() * 25;
+    this.context.fillStyle = `${handle.color}55`;
+    this.context.beginPath();
+    this.context.rect(center.x - radius, center.y - radius, radius * 2, radius * 2);
+    this.context.fill();
+    this.context.strokeStyle = handle.color;
+    this.context.strokeRect(center.x - radius, center.y - radius, radius * 2, radius * 2);
+  }
+
+  private drawRing(camera: CameraState, handle: HandleGeometry): void {
+    if (!handle.normal || !handle.radius) {
+      return;
+    }
+    const center = projectToScreen(camera, handle.start);
+    if (!center) {
+      return;
+    }
+    const worldPoint = Vector3.add(handle.start, Vector3.multiplyByScalar(handle.normal, this.primitive.getScale() * handle.radius, new Vector3()), new Vector3());
+    const edge = projectToScreen(camera, worldPoint);
+    if (!edge) {
+      return;
+    }
+    const radius = Math.hypot(edge.x - center.x, edge.y - center.y);
+    this.context.beginPath();
+    this.context.arc(center.x, center.y, radius, 0, Math.PI * 2);
+    this.context.stroke();
+  }
+
+  private drawCenter(camera: CameraState, handle: HandleGeometry): void {
+    const center = projectToScreen(camera, handle.start);
+    if (!center) {
+      return;
+    }
+    const radius = this.primitive.getScale() * 12;
+    this.context.beginPath();
+    this.context.arc(center.x, center.y, radius, 0, Math.PI * 2);
+    this.context.fillStyle = '#ffffff';
+    this.context.globalAlpha = 0.85;
+    this.context.fill();
+  }
+}

--- a/src/core/HudOverlay.ts
+++ b/src/core/HudOverlay.ts
@@ -1,0 +1,89 @@
+import { HudDisplayValues } from '../types.js';
+import { Vector3 } from '../math/Vector3.js';
+import { toDegrees } from '../math/MathUtils.js';
+
+export class HudOverlay {
+  private readonly root: HTMLElement;
+  private readonly header: HTMLElement;
+  private readonly deltaList: HTMLElement;
+  private visible = true;
+
+  constructor(private readonly container: HTMLElement) {
+    this.root = document.createElement('div');
+    this.root.className = 'gizmo-hud';
+    this.root.style.position = 'absolute';
+    this.root.style.top = '12px';
+    this.root.style.right = '12px';
+    this.root.style.padding = '8px 12px';
+    this.root.style.background = 'rgba(0,0,0,0.6)';
+    this.root.style.color = '#fff';
+    this.root.style.fontFamily = 'monospace';
+    this.root.style.fontSize = '12px';
+    this.root.style.borderRadius = '4px';
+    this.root.style.pointerEvents = 'none';
+
+    this.header = document.createElement('div');
+    this.deltaList = document.createElement('div');
+    this.deltaList.style.marginTop = '4px';
+
+    this.root.appendChild(this.header);
+    this.root.appendChild(this.deltaList);
+    this.container.appendChild(this.root);
+  }
+
+  setVisible(visible: boolean): void {
+    this.visible = visible;
+    this.root.style.display = visible ? 'block' : 'none';
+  }
+
+  update(values: HudDisplayValues): void {
+    if (!this.visible) {
+      return;
+    }
+    this.header.textContent = `${values.mode.toUpperCase()} :: ${values.axisLabel}${values.snapped ? ' (SNAP)' : ''}`;
+    const items: string[] = [];
+    if (values.deltaTranslation) {
+      items.push(`ΔT ${formatVector(values.deltaTranslation)}`);
+    }
+    if (values.deltaRotation) {
+      items.push(`ΔR ${formatAngles(values.deltaRotation)}`);
+    }
+    if (values.deltaScale) {
+      items.push(`ΔS ${formatScale(values.deltaScale)}`);
+    }
+    this.deltaList.innerHTML = items.map((item) => `<div>${item}</div>`).join('');
+  }
+
+  destroy(): void {
+    this.root.remove();
+  }
+}
+
+function formatVector(vector: Vector3): string {
+  return `${formatDistance(vector.x)}, ${formatDistance(vector.y)}, ${formatDistance(vector.z)}`;
+}
+
+function formatDistance(value: number): string {
+  const absValue = Math.abs(value);
+  let unit = 'm';
+  let scaled = value;
+  if (absValue < 0.01) {
+    unit = 'mm';
+    scaled = value * 1000;
+  } else if (absValue < 1) {
+    unit = 'cm';
+    scaled = value * 100;
+  } else if (absValue > 1000) {
+    unit = 'km';
+    scaled = value / 1000;
+  }
+  return `${scaled.toFixed(3)}${unit}`;
+}
+
+function formatAngles(vector: Vector3): string {
+  return `${toDegrees(vector.x).toFixed(2)}°, ${toDegrees(vector.y).toFixed(2)}°, ${toDegrees(vector.z).toFixed(2)}°`;
+}
+
+function formatScale(vector: Vector3): string {
+  return `${vector.x.toFixed(3)}, ${vector.y.toFixed(3)}, ${vector.z.toFixed(3)}`;
+}

--- a/src/core/ManipulatorController.ts
+++ b/src/core/ManipulatorController.ts
@@ -1,0 +1,170 @@
+import { GizmoPicker } from './GizmoPicker.js';
+import { TransformSolver } from './TransformSolver.js';
+import { CameraState } from './CameraState.js';
+import { FrameState, DragContext, PickResult, TransformDelta, SnapRuntimeOptions } from '../types.js';
+import { Vector2 } from '../math/Vector2.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Ray } from '../math/Ray.js';
+import { createIdentityDelta } from '../utils/Transform.js';
+
+export interface PointerModifiers {
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+}
+
+export interface ControllerCallbacks {
+  onHover?(pick: PickResult | undefined): void;
+  onDragStart?(context: DragContext): void;
+  onDrag?(context: DragContext, delta: TransformDelta, snapped: boolean): void;
+  onDragEnd?(context: DragContext, delta: TransformDelta, committed: boolean): void;
+}
+
+export interface ManipulatorControllerOptions {
+  picker: GizmoPicker;
+  solver: TransformSolver;
+  camera: CameraState;
+  callbacks?: ControllerCallbacks;
+  snapEnabled?: boolean;
+}
+
+export class ManipulatorController {
+  private camera: CameraState;
+  private frame: FrameState | undefined;
+  private hover: PickResult | undefined;
+  private activeContext: DragContext | undefined;
+  private snapEnabled: boolean;
+  private callbacks?: ControllerCallbacks;
+
+  constructor(private readonly picker: GizmoPicker, private readonly solver: TransformSolver, options: ManipulatorControllerOptions) {
+    this.camera = options.camera;
+    this.snapEnabled = options.snapEnabled ?? true;
+    this.callbacks = options.callbacks;
+  }
+
+  setCamera(camera: CameraState): void {
+    this.camera = camera;
+  }
+
+  setFrame(frame: FrameState): void {
+    this.frame = frame;
+  }
+
+  setSnapEnabled(enabled: boolean): void {
+    this.snapEnabled = enabled;
+  }
+
+  handlePointerMove(position: Vector2, modifiers: PointerModifiers): void {
+    if (!this.frame) {
+      return;
+    }
+    if (this.activeContext) {
+      this.updateDrag(position, modifiers);
+      return;
+    }
+    const pick = this.picker.pick(this.camera, position);
+    if (pick?.handleId !== this.hover?.handleId) {
+      this.hover = pick;
+      this.callbacks?.onHover?.(pick);
+    }
+  }
+
+  handlePointerDown(position: Vector2, modifiers: PointerModifiers): void {
+    if (!this.frame) {
+      return;
+    }
+    if (this.activeContext) {
+      return;
+    }
+    const pick = this.picker.pick(this.camera, position) ?? this.hover;
+    if (!pick) {
+      return;
+    }
+    const ray = this.computePickRay(position);
+    const context: DragContext = {
+      mode: pick.mode,
+      axis: pick.axis,
+      planeAxis: pick.planeAxis,
+      handleId: pick.handleId,
+      startPointer: { x: position.x, y: position.y },
+      startRayOrigin: ray.origin,
+      startRayDirection: ray.direction,
+      startMatrix: this.frame.matrix.clone(),
+      pivotWorld: Vector3.clone(this.frame.origin),
+      frame: this.frame,
+      currentDelta: createIdentityDelta()
+    };
+    const snapOptions = this.buildSnapOptions(modifiers);
+    this.solver.beginDrag({
+      mode: pick.mode,
+      axis: pick.axis,
+      planeAxis: pick.planeAxis,
+      frame: this.frame,
+      pivotWorld: Vector3.clone(this.frame.origin),
+      startRay: ray,
+      camera: this.camera,
+      snapOptions
+    });
+    this.activeContext = context;
+    this.callbacks?.onDragStart?.(context);
+  }
+
+  handlePointerUp(position: Vector2, modifiers: PointerModifiers, committed = true): void {
+    if (!this.activeContext) {
+      return;
+    }
+    this.updateDrag(position, modifiers);
+    const context = this.activeContext;
+    const delta = context.currentDelta;
+    this.callbacks?.onDragEnd?.(context, delta, committed);
+    this.activeContext = undefined;
+  }
+
+  cancelDrag(): void {
+    if (!this.activeContext) {
+      return;
+    }
+    const context = this.activeContext;
+    const delta = context.currentDelta;
+    this.callbacks?.onDragEnd?.(context, delta, false);
+    this.activeContext = undefined;
+  }
+
+  private updateDrag(position: Vector2, modifiers: PointerModifiers): void {
+    if (!this.activeContext || !this.frame) {
+      return;
+    }
+    const ray = this.computePickRay(position);
+    const snapOptions = this.buildSnapOptions(modifiers);
+    const delta = this.solver.updateDrag(this.activeContext, { currentRay: ray, snapOptions });
+    this.activeContext.currentDelta = delta;
+    this.callbacks?.onDrag?.(this.activeContext, delta, snapOptions.enabled);
+  }
+
+  private computePickRay(position: Vector2): Ray {
+    const ndcX = (2 * position.x) / this.camera.viewportWidth - 1;
+    const ndcY = 1 - (2 * position.y) / this.camera.viewportHeight;
+    const tanFov = Math.tan(this.camera.fov / 2);
+    const dir = Vector3.normalize(
+      Vector3.add(
+        Vector3.add(
+          Vector3.multiplyByScalar(this.camera.right, ndcX * tanFov * this.camera.aspect, new Vector3()),
+          Vector3.multiplyByScalar(this.camera.up, ndcY * tanFov, new Vector3()),
+          new Vector3()
+        ),
+        this.camera.direction,
+        new Vector3()
+      )
+    );
+    return new Ray(this.camera.position, dir);
+  }
+
+  private buildSnapOptions(modifiers: PointerModifiers): SnapRuntimeOptions {
+    return {
+      enabled: this.snapEnabled,
+      fineModifierActive: modifiers.shiftKey,
+      coarseModifierActive: modifiers.ctrlKey || modifiers.metaKey
+    };
+  }
+}

--- a/src/core/PivotResolver.ts
+++ b/src/core/PivotResolver.ts
@@ -1,0 +1,69 @@
+import { Vector3 } from '../math/Vector3.js';
+import { CursorProvider, Pivot, TransformTarget } from '../types.js';
+
+const scratchTranslation = new Vector3();
+
+export class PivotResolver {
+  constructor(private readonly cursorProvider?: CursorProvider) {}
+
+  resolveManipulatorPivot(pivot: Pivot, targets: TransformTarget[]): Vector3 {
+    if (targets.length === 0) {
+      return new Vector3();
+    }
+    switch (pivot) {
+      case 'origin':
+        return this.extractTranslation(targets[0]);
+      case 'median':
+        return this.computeMedian(targets);
+      case 'cursor': {
+        const cursorPosition = this.cursorProvider?.getCursorPosition();
+        return cursorPosition ? Vector3.clone(cursorPosition) : this.computeMedian(targets);
+      }
+      case 'individual':
+        return this.computeMedian(targets);
+      default:
+        return this.computeMedian(targets);
+    }
+  }
+
+  resolvePerTargetPivot(pivot: Pivot, targets: TransformTarget[], manipulatorPivot: Vector3): Map<string, Vector3> {
+    const map = new Map<string, Vector3>();
+    for (const target of targets) {
+      switch (pivot) {
+        case 'origin':
+          map.set(target.id, this.extractTranslation(target));
+          break;
+        case 'median':
+        case 'cursor':
+          map.set(target.id, new Vector3(manipulatorPivot.x, manipulatorPivot.y, manipulatorPivot.z));
+          break;
+        case 'individual':
+          map.set(target.id, this.extractTranslation(target));
+          break;
+        default:
+          map.set(target.id, new Vector3(manipulatorPivot.x, manipulatorPivot.y, manipulatorPivot.z));
+      }
+    }
+    return map;
+  }
+
+  private extractTranslation(target: TransformTarget): Vector3 {
+    const matrix = target.getMatrix();
+    return matrix.getTranslation(new Vector3());
+  }
+
+  private computeMedian(targets: TransformTarget[]): Vector3 {
+    if (targets.length === 0) {
+      return new Vector3();
+    }
+    const sum = new Vector3();
+    for (const target of targets) {
+      const translation = target.getMatrix().getTranslation(scratchTranslation);
+      sum.x += translation.x;
+      sum.y += translation.y;
+      sum.z += translation.z;
+    }
+    const inv = 1.0 / targets.length;
+    return new Vector3(sum.x * inv, sum.y * inv, sum.z * inv);
+  }
+}

--- a/src/core/Snapper.ts
+++ b/src/core/Snapper.ts
@@ -1,0 +1,56 @@
+import { SnapRuntimeOptions, SnapStepConfig } from '../types.js';
+
+const DEFAULT_SNAP: SnapStepConfig = {
+  translate: 1.0,
+  rotate: (5 * Math.PI) / 180,
+  scale: 0.1,
+  fineModifier: 0.1,
+  coarseModifier: 10
+};
+
+export class Snapper {
+  private config: SnapStepConfig;
+
+  constructor(config?: SnapStepConfig) {
+    this.config = config ?? { ...DEFAULT_SNAP };
+  }
+
+  setConfig(config?: SnapStepConfig): void {
+    this.config = config ?? { ...DEFAULT_SNAP };
+  }
+
+  snapTranslation(value: number, runtime: SnapRuntimeOptions): number {
+    return runtime.enabled ? this.snapScalar(value, runtime, this.config.translate) : value;
+  }
+
+  snapRotation(value: number, runtime: SnapRuntimeOptions): number {
+    return runtime.enabled ? this.snapScalar(value, runtime, this.config.rotate) : value;
+  }
+
+  snapScale(value: number, runtime: SnapRuntimeOptions, base = 1): number {
+    if (!runtime.enabled) {
+      return value;
+    }
+    const snapped = this.snapScalar(value - base, runtime, this.config.scale);
+    return base + snapped;
+  }
+
+  private snapScalar(value: number, runtime: SnapRuntimeOptions, step: number): number {
+    const effectiveStep = this.getEffectiveStep(step, runtime);
+    if (effectiveStep <= 0) {
+      return value;
+    }
+    return Math.round(value / effectiveStep) * effectiveStep;
+  }
+
+  private getEffectiveStep(step: number, runtime: SnapRuntimeOptions): number {
+    let result = step;
+    if (runtime.fineModifierActive) {
+      result *= this.config.fineModifier ?? 0.1;
+    }
+    if (runtime.coarseModifierActive) {
+      result *= this.config.coarseModifier ?? 10;
+    }
+    return result;
+  }
+}

--- a/src/core/TransformSolver.ts
+++ b/src/core/TransformSolver.ts
@@ -1,0 +1,215 @@
+import { Ray } from '../math/Ray.js';
+import { Plane } from '../math/Plane.js';
+import { Quaternion } from '../math/Quaternion.js';
+import { Vector3 } from '../math/Vector3.js';
+import { Axis, DragContext, FrameState, Mode, SnapRuntimeOptions, TransformDelta } from '../types.js';
+import { createIdentityDelta } from '../utils/Transform.js';
+import { Snapper } from './Snapper.js';
+import { CameraState } from './CameraState.js';
+
+interface DragComputationState {
+  mode: Mode;
+  axis?: Axis;
+  planeAxis?: [Axis, Axis];
+  axisDirection?: Vector3;
+  planeAxes?: [Vector3, Vector3];
+  planeNormal?: Vector3;
+  startParam?: number;
+  startPoint?: Vector3;
+  startVector?: Vector3;
+  startRadius?: number;
+}
+
+const axisMap: Record<Axis, (frame: FrameState) => Vector3> = {
+  x: (frame) => frame.axes.x,
+  y: (frame) => frame.axes.y,
+  z: (frame) => frame.axes.z
+};
+
+export interface DragStartOptions {
+  mode: Mode;
+  axis?: Axis;
+  planeAxis?: [Axis, Axis];
+  frame: FrameState;
+  pivotWorld: Vector3;
+  startRay: Ray;
+  camera: CameraState;
+  snapOptions: SnapRuntimeOptions;
+}
+
+export interface DragUpdateOptions {
+  currentRay: Ray;
+  snapOptions: SnapRuntimeOptions;
+}
+
+export class TransformSolver {
+  private computationState: DragComputationState | undefined;
+
+  constructor(private readonly snapper: Snapper) {}
+
+  beginDrag(options: DragStartOptions): DragComputationState {
+    const { mode, axis, planeAxis, frame, pivotWorld, startRay, camera } = options;
+    const state: DragComputationState = { mode, axis, planeAxis };
+    switch (mode) {
+      case 'translate':
+        if (axis) {
+          state.axisDirection = axisMap[axis](frame);
+          state.startParam = this.projectRayToAxis(startRay, pivotWorld, state.axisDirection);
+        } else if (planeAxis) {
+          state.planeAxes = [axisMap[planeAxis[0]](frame), axisMap[planeAxis[1]](frame)];
+          state.planeNormal = Vector3.normalize(Vector3.cross(state.planeAxes[0], state.planeAxes[1], new Vector3()));
+          state.startPoint = this.intersectRayWithPlane(startRay, pivotWorld, state.planeNormal) ?? pivotWorld;
+        } else {
+          // free translate in view plane
+          const planeNormal = camera.direction;
+          state.planeNormal = planeNormal;
+          const axisX = frame.axes.x;
+          const axisY = frame.axes.y;
+          state.planeAxes = [axisX, axisY];
+          state.startPoint = this.intersectRayWithPlane(startRay, pivotWorld, planeNormal) ?? pivotWorld;
+        }
+        break;
+      case 'rotate':
+        state.axisDirection = axis ? axisMap[axis](frame) : camera.direction;
+        state.planeNormal = state.axisDirection;
+        state.startPoint = this.intersectRayWithPlane(startRay, pivotWorld, state.axisDirection) ?? pivotWorld;
+        state.startVector = Vector3.normalize(Vector3.subtract(state.startPoint, pivotWorld, new Vector3()));
+        break;
+      case 'scale':
+        if (axis) {
+          state.axisDirection = axisMap[axis](frame);
+          state.startParam = this.projectRayToAxis(startRay, pivotWorld, state.axisDirection);
+        } else {
+          const viewNormal = camera.direction;
+          state.planeNormal = viewNormal;
+          state.startPoint = this.intersectRayWithPlane(startRay, pivotWorld, viewNormal) ?? pivotWorld;
+          state.startRadius = Math.max(1e-6, Vector3.magnitude(Vector3.subtract(state.startPoint, pivotWorld, new Vector3())));
+        }
+        break;
+    }
+    this.computationState = state;
+    return state;
+  }
+
+  updateDrag(context: DragContext, options: DragUpdateOptions): TransformDelta {
+    if (!this.computationState) {
+      throw new Error('Drag has not been initialized');
+    }
+    const { currentRay, snapOptions } = options;
+    switch (this.computationState.mode) {
+      case 'translate':
+        return this.computeTranslationDelta(context, currentRay, snapOptions);
+      case 'rotate':
+        return this.computeRotationDelta(context, currentRay, snapOptions);
+      case 'scale':
+        return this.computeScaleDelta(context, currentRay, snapOptions);
+      default:
+        return createIdentityDelta();
+    }
+  }
+
+  private computeTranslationDelta(context: DragContext, ray: Ray, snapOptions: SnapRuntimeOptions): TransformDelta {
+    const state = this.computationState!;
+    const delta = createIdentityDelta();
+    if (state.axisDirection && typeof state.startParam === 'number') {
+      const currentParam = this.projectRayToAxis(ray, context.pivotWorld, state.axisDirection);
+      let value = currentParam - state.startParam;
+      value = this.snapper.snapTranslation(value, snapOptions);
+      delta.translation = Vector3.multiplyByScalar(state.axisDirection, value);
+      return delta;
+    }
+    if (state.planeAxes && state.planeNormal && state.startPoint) {
+      const point = this.intersectRayWithPlane(ray, context.pivotWorld, state.planeNormal) ?? state.startPoint;
+      const diff = Vector3.subtract(point, state.startPoint, new Vector3());
+      const axisA = state.planeAxes[0];
+      const axisB = state.planeAxes[1];
+      let scalarA = Vector3.dot(diff, axisA);
+      let scalarB = Vector3.dot(diff, axisB);
+      scalarA = this.snapper.snapTranslation(scalarA, snapOptions);
+      scalarB = this.snapper.snapTranslation(scalarB, snapOptions);
+      const contributionA = Vector3.multiplyByScalar(axisA, scalarA, new Vector3());
+      const contributionB = Vector3.multiplyByScalar(axisB, scalarB, new Vector3());
+      delta.translation = Vector3.add(contributionA, contributionB, new Vector3());
+      return delta;
+    }
+    return delta;
+  }
+
+  private computeRotationDelta(context: DragContext, ray: Ray, snapOptions: SnapRuntimeOptions): TransformDelta {
+    const state = this.computationState!;
+    const delta = createIdentityDelta();
+    if (!state.axisDirection || !state.startVector) {
+      return delta;
+    }
+    const point = this.intersectRayWithPlane(ray, context.pivotWorld, state.axisDirection) ?? context.pivotWorld;
+    const vector = Vector3.subtract(point, context.pivotWorld, new Vector3());
+    if (Vector3.magnitudeSquared(vector) < 1e-12) {
+      delta.rotation = Quaternion.identity();
+      return delta;
+    }
+    const currentVector = Vector3.normalize(vector, new Vector3());
+    const angle = this.signedAngle(state.startVector, currentVector, state.axisDirection);
+    const snapped = this.snapper.snapRotation(angle, snapOptions);
+    delta.rotation = Quaternion.fromAxisAngle(state.axisDirection, snapped);
+    return delta;
+  }
+
+  private computeScaleDelta(context: DragContext, ray: Ray, snapOptions: SnapRuntimeOptions): TransformDelta {
+    const state = this.computationState!;
+    const delta = createIdentityDelta();
+    if (state.axisDirection && typeof state.startParam === 'number') {
+      const currentParam = this.projectRayToAxis(ray, context.pivotWorld, state.axisDirection);
+      const deltaParam = currentParam - state.startParam;
+      const snapped = this.snapper.snapScale(1 + deltaParam, snapOptions, 1);
+      const scaleVector = new Vector3(1, 1, 1);
+      switch (state.axis) {
+        case 'x':
+          scaleVector.x = snapped;
+          break;
+        case 'y':
+          scaleVector.y = snapped;
+          break;
+        case 'z':
+          scaleVector.z = snapped;
+          break;
+      }
+      delta.scale = scaleVector;
+      return delta;
+    }
+    if (state.startPoint && state.startRadius) {
+      const point = this.intersectRayWithPlane(ray, context.pivotWorld, state.planeNormal ?? context.frame.axes.z) ?? state.startPoint;
+      const currentRadius = Math.max(1e-6, Vector3.magnitude(Vector3.subtract(point, context.pivotWorld, new Vector3())));
+      const raw = currentRadius / state.startRadius;
+      const snapped = this.snapper.snapScale(raw, snapOptions, 1);
+      delta.scale = new Vector3(snapped, snapped, snapped);
+      return delta;
+    }
+    return delta;
+  }
+
+  private projectRayToAxis(ray: Ray, origin: Vector3, axis: Vector3): number {
+    const w0 = Vector3.subtract(ray.origin, origin, new Vector3());
+    const a = Vector3.dot(axis, axis);
+    const b = Vector3.dot(axis, ray.direction);
+    const c = Vector3.dot(ray.direction, ray.direction);
+    const d = Vector3.dot(axis, w0);
+    const e = Vector3.dot(ray.direction, w0);
+    const denom = a * c - b * b;
+    if (Math.abs(denom) < 1e-12) {
+      return Vector3.dot(axis, w0);
+    }
+    return (b * e - c * d) / denom;
+  }
+
+  private intersectRayWithPlane(ray: Ray, pointOnPlane: Vector3, planeNormal: Vector3): Vector3 | undefined {
+    const plane = Plane.fromPointNormal(pointOnPlane, planeNormal);
+    return Plane.intersectRay(ray, plane);
+  }
+
+  private signedAngle(from: Vector3, to: Vector3, axis: Vector3): number {
+    const dot = Vector3.dot(from, to);
+    const cross = Vector3.cross(from, to, new Vector3());
+    const angle = Math.atan2(Vector3.dot(cross, axis), dot);
+    return angle;
+  }
+}

--- a/src/core/projection.ts
+++ b/src/core/projection.ts
@@ -1,0 +1,28 @@
+import { CameraState } from './CameraState.js';
+import { Vector3 } from '../math/Vector3.js';
+
+export interface ScreenPoint {
+  x: number;
+  y: number;
+  depth: number;
+}
+
+export function projectToScreen(camera: CameraState, point: Vector3): ScreenPoint | undefined {
+  const e = camera.viewProjectionMatrix.elements;
+  const x = point.x;
+  const y = point.y;
+  const z = point.z;
+  const clipX = e[0] * x + e[4] * y + e[8] * z + e[12];
+  const clipY = e[1] * x + e[5] * y + e[9] * z + e[13];
+  const clipZ = e[2] * x + e[6] * y + e[10] * z + e[14];
+  const clipW = e[3] * x + e[7] * y + e[11] * z + e[15];
+  if (clipW === 0) {
+    return undefined;
+  }
+  const ndcX = clipX / clipW;
+  const ndcY = clipY / clipW;
+  const ndcZ = clipZ / clipW;
+  const screenX = (ndcX * 0.5 + 0.5) * camera.viewportWidth;
+  const screenY = (1 - (ndcY * 0.5 + 0.5)) * camera.viewportHeight;
+  return { x: screenX, y: screenY, depth: ndcZ };
+}

--- a/src/core/targets/MatrixTransformTarget.ts
+++ b/src/core/targets/MatrixTransformTarget.ts
@@ -1,0 +1,22 @@
+import { Matrix4 } from '../../math/Matrix4.js';
+import { TransformTarget } from '../../types.js';
+
+let idCounter = 0;
+
+export class MatrixTransformTarget implements TransformTarget {
+  readonly id: string;
+  private matrix: Matrix4;
+
+  constructor(initialMatrix = Matrix4.identity()) {
+    this.id = `target-${idCounter++}`;
+    this.matrix = initialMatrix.clone();
+  }
+
+  getMatrix(result = new Matrix4()): Matrix4 {
+    return this.matrix.clone(result);
+  }
+
+  setMatrix(matrix: Matrix4): void {
+    this.matrix = matrix.clone(new Matrix4());
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,7 @@
+export * from './UniversalManipulator.js';
+export * from './core/CameraState.js';
+export * from './core/targets/MatrixTransformTarget.js';
+export * from './types.js';
+export * from './math/Vector3.js';
+export * from './math/Matrix4.js';
+export * from './math/Quaternion.js';

--- a/src/math/MathUtils.ts
+++ b/src/math/MathUtils.ts
@@ -1,0 +1,17 @@
+export const EPSILON = 1e-10;
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function toDegrees(radians: number): number {
+  return radians * (180 / Math.PI);
+}
+
+export function toRadians(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}
+
+export function approxEquals(a: number, b: number, epsilon = EPSILON): boolean {
+  return Math.abs(a - b) <= epsilon;
+}

--- a/src/math/Matrix3.ts
+++ b/src/math/Matrix3.ts
@@ -1,0 +1,105 @@
+import { Vector3 } from './Vector3.js';
+
+export class Matrix3 {
+  elements: Float64Array;
+
+  constructor(elements?: Iterable<number>) {
+    this.elements = new Float64Array(9);
+    if (elements) {
+      let i = 0;
+      for (const value of elements) {
+        this.elements[i++] = value;
+      }
+    } else {
+      this.identity();
+    }
+  }
+
+  static identity(): Matrix3 {
+    return new Matrix3().identity();
+  }
+
+  clone(result = new Matrix3()): Matrix3 {
+    result.elements.set(this.elements);
+    return result;
+  }
+
+  identity(): Matrix3 {
+    const e = this.elements;
+    e[0] = 1; e[1] = 0; e[2] = 0;
+    e[3] = 0; e[4] = 1; e[5] = 0;
+    e[6] = 0; e[7] = 0; e[8] = 1;
+    return this;
+  }
+
+  setFromColumns(x: Vector3, y: Vector3, z: Vector3): Matrix3 {
+    const e = this.elements;
+    e[0] = x.x; e[1] = x.y; e[2] = x.z;
+    e[3] = y.x; e[4] = y.y; e[5] = y.z;
+    e[6] = z.x; e[7] = z.y; e[8] = z.z;
+    return this;
+  }
+
+  multiplyVector(vector: Vector3, result = new Vector3()): Vector3 {
+    const e = this.elements;
+    const x = vector.x;
+    const y = vector.y;
+    const z = vector.z;
+    result.x = e[0] * x + e[3] * y + e[6] * z;
+    result.y = e[1] * x + e[4] * y + e[7] * z;
+    result.z = e[2] * x + e[5] * y + e[8] * z;
+    return result;
+  }
+
+  transpose(result = new Matrix3()): Matrix3 {
+    const e = this.elements;
+    result.elements.set([
+      e[0], e[3], e[6],
+      e[1], e[4], e[7],
+      e[2], e[5], e[8]
+    ]);
+    return result;
+  }
+
+  multiply(other: Matrix3, result = new Matrix3()): Matrix3 {
+    const a = this.elements;
+    const b = other.elements;
+    const r = result.elements;
+    for (let row = 0; row < 3; row++) {
+      for (let col = 0; col < 3; col++) {
+        const index = col * 3 + row;
+        r[index] = a[row] * b[col * 3] + a[row + 3] * b[col * 3 + 1] + a[row + 6] * b[col * 3 + 2];
+      }
+    }
+    return result;
+  }
+
+  determinant(): number {
+    const e = this.elements;
+    return (
+      e[0] * (e[4] * e[8] - e[7] * e[5]) -
+      e[3] * (e[1] * e[8] - e[7] * e[2]) +
+      e[6] * (e[1] * e[5] - e[4] * e[2])
+    );
+  }
+
+  invert(result = new Matrix3()): Matrix3 {
+    const det = this.determinant();
+    if (Math.abs(det) < 1e-12) {
+      throw new Error('Matrix3 is singular and cannot be inverted.');
+    }
+    const invDet = 1.0 / det;
+    const e = this.elements;
+    const r = result.elements;
+    r[0] = (e[4] * e[8] - e[7] * e[5]) * invDet;
+    r[1] = (e[7] * e[2] - e[1] * e[8]) * invDet;
+    r[2] = (e[1] * e[5] - e[4] * e[2]) * invDet;
+    r[3] = (e[6] * e[5] - e[3] * e[8]) * invDet;
+    r[4] = (e[0] * e[8] - e[6] * e[2]) * invDet;
+    r[5] = (e[3] * e[2] - e[0] * e[5]) * invDet;
+    r[6] = (e[3] * e[7] - e[6] * e[4]) * invDet;
+    r[7] = (e[6] * e[1] - e[0] * e[7]) * invDet;
+    r[8] = (e[0] * e[4] - e[3] * e[1]) * invDet;
+    return result;
+  }
+}

--- a/src/math/Matrix4.ts
+++ b/src/math/Matrix4.ts
@@ -1,0 +1,185 @@
+import { Matrix3 } from './Matrix3.js';
+import { Quaternion } from './Quaternion.js';
+import { Vector3 } from './Vector3.js';
+
+export class Matrix4 {
+  elements: Float64Array;
+
+  constructor(elements?: Iterable<number>) {
+    this.elements = new Float64Array(16);
+    if (elements) {
+      let i = 0;
+      for (const value of elements) {
+        this.elements[i++] = value;
+      }
+    } else {
+      this.identity();
+    }
+  }
+
+  static identity(): Matrix4 {
+    return new Matrix4().identity();
+  }
+
+  clone(result = new Matrix4()): Matrix4 {
+    result.elements.set(this.elements);
+    return result;
+  }
+
+  identity(): Matrix4 {
+    const e = this.elements;
+    e[0] = 1; e[1] = 0; e[2] = 0; e[3] = 0;
+    e[4] = 0; e[5] = 1; e[6] = 0; e[7] = 0;
+    e[8] = 0; e[9] = 0; e[10] = 1; e[11] = 0;
+    e[12] = 0; e[13] = 0; e[14] = 0; e[15] = 1;
+    return this;
+  }
+
+  static fromTranslationRotationScale(translation: Vector3, rotation: Quaternion, scale: Vector3, result = new Matrix4()): Matrix4 {
+    const rotMatrix = rotation.toMatrix3(new Matrix3());
+    const e = result.elements;
+    const rm = rotMatrix.elements;
+    e[0] = rm[0] * scale.x; e[1] = rm[1] * scale.x; e[2] = rm[2] * scale.x; e[3] = 0;
+    e[4] = rm[3] * scale.y; e[5] = rm[4] * scale.y; e[6] = rm[5] * scale.y; e[7] = 0;
+    e[8] = rm[6] * scale.z; e[9] = rm[7] * scale.z; e[10] = rm[8] * scale.z; e[11] = 0;
+    e[12] = translation.x; e[13] = translation.y; e[14] = translation.z; e[15] = 1;
+    return result;
+  }
+
+  static fromColumns(x: Vector3, y: Vector3, z: Vector3, w: Vector3, result = new Matrix4()): Matrix4 {
+    const e = result.elements;
+    e[0] = x.x; e[1] = x.y; e[2] = x.z; e[3] = 0;
+    e[4] = y.x; e[5] = y.y; e[6] = y.z; e[7] = 0;
+    e[8] = z.x; e[9] = z.y; e[10] = z.z; e[11] = 0;
+    e[12] = w.x; e[13] = w.y; e[14] = w.z; e[15] = 1;
+    return result;
+  }
+
+  multiply(other: Matrix4, result = new Matrix4()): Matrix4 {
+    const a = this.elements;
+    const b = other.elements;
+    const r = result.elements;
+    for (let row = 0; row < 4; row++) {
+      for (let col = 0; col < 4; col++) {
+        const index = col * 4 + row;
+        r[index] =
+          a[row] * b[col * 4] +
+          a[row + 4] * b[col * 4 + 1] +
+          a[row + 8] * b[col * 4 + 2] +
+          a[row + 12] * b[col * 4 + 3];
+      }
+    }
+    return result;
+  }
+
+  transformVector(vector: Vector3, result = new Vector3()): Vector3 {
+    const e = this.elements;
+    const x = vector.x;
+    const y = vector.y;
+    const z = vector.z;
+    result.x = e[0] * x + e[4] * y + e[8] * z + e[12];
+    result.y = e[1] * x + e[5] * y + e[9] * z + e[13];
+    result.z = e[2] * x + e[6] * y + e[10] * z + e[14];
+    return result;
+  }
+
+  transformDirection(direction: Vector3, result = new Vector3()): Vector3 {
+    const e = this.elements;
+    const x = direction.x;
+    const y = direction.y;
+    const z = direction.z;
+    result.x = e[0] * x + e[4] * y + e[8] * z;
+    result.y = e[1] * x + e[5] * y + e[9] * z;
+    result.z = e[2] * x + e[6] * y + e[10] * z;
+    return result;
+  }
+
+  invert(result = new Matrix4()): Matrix4 {
+    const e = this.elements;
+    const r = result.elements;
+    const m00 = e[0], m01 = e[4], m02 = e[8], m03 = e[12];
+    const m10 = e[1], m11 = e[5], m12 = e[9], m13 = e[13];
+    const m20 = e[2], m21 = e[6], m22 = e[10], m23 = e[14];
+    const m30 = e[3], m31 = e[7], m32 = e[11], m33 = e[15];
+
+    const tmp0 = m22 * m33 - m32 * m23;
+    const tmp1 = m21 * m33 - m31 * m23;
+    const tmp2 = m21 * m32 - m31 * m22;
+    const tmp3 = m20 * m33 - m30 * m23;
+    const tmp4 = m20 * m32 - m30 * m22;
+    const tmp5 = m20 * m31 - m30 * m21;
+
+    const cof00 = m11 * tmp0 - m12 * tmp1 + m13 * tmp2;
+    const cof01 = -(m10 * tmp0 - m12 * tmp3 + m13 * tmp4);
+    const cof02 = m10 * tmp1 - m11 * tmp3 + m13 * tmp5;
+    const cof03 = -(m10 * tmp2 - m11 * tmp4 + m12 * tmp5);
+
+    const det = m00 * cof00 + m01 * cof01 + m02 * cof02 + m03 * cof03;
+    if (Math.abs(det) < 1e-12) {
+      throw new Error('Matrix4 is singular and cannot be inverted.');
+    }
+
+    const invDet = 1.0 / det;
+
+    r[0] = cof00 * invDet;
+    r[4] = cof01 * invDet;
+    r[8] = cof02 * invDet;
+    r[12] = cof03 * invDet;
+
+    r[1] = -(m01 * tmp0 - m02 * tmp1 + m03 * tmp2) * invDet;
+    r[5] = (m00 * tmp0 - m02 * tmp3 + m03 * tmp4) * invDet;
+    r[9] = -(m00 * tmp1 - m01 * tmp3 + m03 * tmp5) * invDet;
+    r[13] = (m00 * tmp2 - m01 * tmp4 + m02 * tmp5) * invDet;
+
+    const tmp6 = m12 * m33 - m32 * m13;
+    const tmp7 = m11 * m33 - m31 * m13;
+    const tmp8 = m11 * m32 - m31 * m12;
+    const tmp9 = m10 * m33 - m30 * m13;
+    const tmp10 = m10 * m32 - m30 * m12;
+    const tmp11 = m10 * m31 - m30 * m11;
+
+    r[2] = (m01 * tmp6 - m02 * tmp7 + m03 * tmp8) * invDet;
+    r[6] = -(m00 * tmp6 - m02 * tmp9 + m03 * tmp10) * invDet;
+    r[10] = (m00 * tmp7 - m01 * tmp9 + m03 * tmp11) * invDet;
+    r[14] = -(m00 * tmp8 - m01 * tmp10 + m02 * tmp11) * invDet;
+
+    const tmp12 = m12 * m23 - m22 * m13;
+    const tmp13 = m11 * m23 - m21 * m13;
+    const tmp14 = m11 * m22 - m21 * m12;
+    const tmp15 = m10 * m23 - m20 * m13;
+    const tmp16 = m10 * m22 - m20 * m12;
+    const tmp17 = m10 * m21 - m20 * m11;
+
+    r[3] = -(m01 * tmp12 - m02 * tmp13 + m03 * tmp14) * invDet;
+    r[7] = (m00 * tmp12 - m02 * tmp15 + m03 * tmp16) * invDet;
+    r[11] = -(m00 * tmp13 - m01 * tmp15 + m03 * tmp17) * invDet;
+    r[15] = (m00 * tmp14 - m01 * tmp16 + m02 * tmp17) * invDet;
+
+    return result;
+  }
+
+  getTranslation(result = new Vector3()): Vector3 {
+    result.x = this.elements[12];
+    result.y = this.elements[13];
+    result.z = this.elements[14];
+    return result;
+  }
+
+  getRotation(result = new Matrix3()): Matrix3 {
+    const e = this.elements;
+    result.elements.set([
+      e[0], e[1], e[2],
+      e[4], e[5], e[6],
+      e[8], e[9], e[10]
+    ]);
+    return result;
+  }
+
+  getScale(result = new Vector3()): Vector3 {
+    const e = this.elements;
+    result.x = Math.hypot(e[0], e[1], e[2]);
+    result.y = Math.hypot(e[4], e[5], e[6]);
+    result.z = Math.hypot(e[8], e[9], e[10]);
+    return result;
+  }
+}

--- a/src/math/Plane.ts
+++ b/src/math/Plane.ts
@@ -1,0 +1,31 @@
+import { Vector3 } from './Vector3.js';
+import { Ray } from './Ray.js';
+
+export class Plane {
+  normal: Vector3;
+  distance: number;
+
+  constructor(normal = new Vector3(0, 1, 0), distance = 0) {
+    this.normal = Vector3.normalize(normal);
+    this.distance = distance;
+  }
+
+  static fromPointNormal(point: Vector3, normal: Vector3, result = new Plane()): Plane {
+    const normalized = Vector3.normalize(normal, new Vector3());
+    result.normal = normalized;
+    result.distance = Vector3.dot(normalized, point);
+    return result;
+  }
+
+  static intersectRay(ray: Ray, plane: Plane): Vector3 | undefined {
+    const denom = Vector3.dot(plane.normal, ray.direction);
+    if (Math.abs(denom) < 1e-10) {
+      return undefined;
+    }
+    const t = (plane.distance - Vector3.dot(plane.normal, ray.origin)) / denom;
+    if (t < 0) {
+      return undefined;
+    }
+    return Ray.getPoint(ray, t, new Vector3());
+  }
+}

--- a/src/math/Quaternion.ts
+++ b/src/math/Quaternion.ts
@@ -1,0 +1,187 @@
+import { Matrix3 } from './Matrix3.js';
+import { Vector3 } from './Vector3.js';
+
+export class Quaternion {
+  x: number;
+  y: number;
+  z: number;
+  w: number;
+
+  constructor(x = 0, y = 0, z = 0, w = 1) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+    this.w = w;
+  }
+
+  static identity(): Quaternion {
+    return new Quaternion(0, 0, 0, 1);
+  }
+
+  static fromAxisAngle(axis: Vector3, angle: number, result = new Quaternion()): Quaternion {
+    const halfAngle = angle * 0.5;
+    const s = Math.sin(halfAngle);
+    const normalizedAxis = Vector3.normalize(axis, new Vector3());
+    result.x = normalizedAxis.x * s;
+    result.y = normalizedAxis.y * s;
+    result.z = normalizedAxis.z * s;
+    result.w = Math.cos(halfAngle);
+    return result;
+  }
+
+  static fromRotationMatrix(matrix: Matrix3, result = new Quaternion()): Quaternion {
+    const m = matrix.elements;
+    const trace = m[0] + m[4] + m[8];
+    if (trace > 0) {
+      const s = Math.sqrt(trace + 1.0) * 2;
+      result.w = 0.25 * s;
+      result.x = (m[7] - m[5]) / s;
+      result.y = (m[2] - m[6]) / s;
+      result.z = (m[3] - m[1]) / s;
+    } else if (m[0] > m[4] && m[0] > m[8]) {
+      const s = Math.sqrt(1.0 + m[0] - m[4] - m[8]) * 2;
+      result.w = (m[7] - m[5]) / s;
+      result.x = 0.25 * s;
+      result.y = (m[1] + m[3]) / s;
+      result.z = (m[2] + m[6]) / s;
+    } else if (m[4] > m[8]) {
+      const s = Math.sqrt(1.0 + m[4] - m[0] - m[8]) * 2;
+      result.w = (m[2] - m[6]) / s;
+      result.x = (m[1] + m[3]) / s;
+      result.y = 0.25 * s;
+      result.z = (m[5] + m[7]) / s;
+    } else {
+      const s = Math.sqrt(1.0 + m[8] - m[0] - m[4]) * 2;
+      result.w = (m[3] - m[1]) / s;
+      result.x = (m[2] + m[6]) / s;
+      result.y = (m[5] + m[7]) / s;
+      result.z = 0.25 * s;
+    }
+    return result.normalize();
+  }
+
+  static multiply(a: Quaternion, b: Quaternion, result = new Quaternion()): Quaternion {
+    const ax = a.x, ay = a.y, az = a.z, aw = a.w;
+    const bx = b.x, by = b.y, bz = b.z, bw = b.w;
+    result.x = aw * bx + ax * bw + ay * bz - az * by;
+    result.y = aw * by - ax * bz + ay * bw + az * bx;
+    result.z = aw * bz + ax * by - ay * bx + az * bw;
+    result.w = aw * bw - ax * bx - ay * by - az * bz;
+    return result;
+  }
+
+  static slerp(a: Quaternion, b: Quaternion, t: number, result = new Quaternion()): Quaternion {
+    let cosTheta = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+    let bx = b.x;
+    let by = b.y;
+    let bz = b.z;
+    let bw = b.w;
+
+    if (cosTheta < 0) {
+      cosTheta = -cosTheta;
+      bx = -bx;
+      by = -by;
+      bz = -bz;
+      bw = -bw;
+    }
+
+    if (cosTheta > 0.9995) {
+      result.x = a.x + t * (bx - a.x);
+      result.y = a.y + t * (by - a.y);
+      result.z = a.z + t * (bz - a.z);
+      result.w = a.w + t * (bw - a.w);
+      return result.normalize();
+    }
+
+    const theta0 = Math.acos(cosTheta);
+    const sinTheta0 = Math.sqrt(1.0 - cosTheta * cosTheta);
+    const theta = theta0 * t;
+    const sinTheta = Math.sin(theta);
+    const sinTheta1 = Math.sin(theta0 - theta);
+
+    const s0 = sinTheta1 / sinTheta0;
+    const s1 = sinTheta / sinTheta0;
+
+    result.x = a.x * s0 + bx * s1;
+    result.y = a.y * s0 + by * s1;
+    result.z = a.z * s0 + bz * s1;
+    result.w = a.w * s0 + bw * s1;
+    return result;
+  }
+
+  normalize(): Quaternion {
+    const mag = Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w);
+    if (mag === 0) {
+      this.x = this.y = this.z = 0;
+      this.w = 1;
+      return this;
+    }
+    const invMag = 1.0 / mag;
+    this.x *= invMag;
+    this.y *= invMag;
+    this.z *= invMag;
+    this.w *= invMag;
+    return this;
+  }
+
+  toMatrix3(result = new Matrix3()): Matrix3 {
+    const x = this.x, y = this.y, z = this.z, w = this.w;
+    const xx = x * x, yy = y * y, zz = z * z;
+    const xy = x * y, xz = x * z, yz = y * z;
+    const wx = w * x, wy = w * y, wz = w * z;
+    result.elements.set([
+      1 - 2 * (yy + zz),
+      2 * (xy + wz),
+      2 * (xz - wy),
+      2 * (xy - wz),
+      1 - 2 * (xx + zz),
+      2 * (yz + wx),
+      2 * (xz + wy),
+      2 * (yz - wx),
+      1 - 2 * (xx + yy)
+    ]);
+    return result;
+  }
+
+  static fromEuler(heading: number, pitch: number, roll: number, result = new Quaternion()): Quaternion {
+    const halfHeading = heading * 0.5;
+    const halfPitch = pitch * 0.5;
+    const halfRoll = roll * 0.5;
+
+    const c1 = Math.cos(halfHeading);
+    const s1 = Math.sin(halfHeading);
+    const c2 = Math.cos(halfPitch);
+    const s2 = Math.sin(halfPitch);
+    const c3 = Math.cos(halfRoll);
+    const s3 = Math.sin(halfRoll);
+
+    result.w = c1 * c2 * c3 + s1 * s2 * s3;
+    result.x = s1 * c2 * c3 - c1 * s2 * s3;
+    result.y = c1 * s2 * c3 + s1 * c2 * s3;
+    result.z = c1 * c2 * s3 - s1 * s2 * c3;
+    return result;
+  }
+
+  toEuler(result = new Vector3()): Vector3 {
+    const x = this.x;
+    const y = this.y;
+    const z = this.z;
+    const w = this.w;
+
+    const sinrCosp = 2 * (w * x + y * z);
+    const cosrCosp = 1 - 2 * (x * x + y * y);
+    result.x = Math.atan2(sinrCosp, cosrCosp);
+
+    const sinp = 2 * (w * y - z * x);
+    if (Math.abs(sinp) >= 1) {
+      result.y = Math.sign(sinp) * (Math.PI / 2);
+    } else {
+      result.y = Math.asin(sinp);
+    }
+
+    const sinyCosp = 2 * (w * z + x * y);
+    const cosyCosp = 1 - 2 * (y * y + z * z);
+    result.z = Math.atan2(sinyCosp, cosyCosp);
+    return result;
+  }
+}

--- a/src/math/Ray.ts
+++ b/src/math/Ray.ts
@@ -1,0 +1,18 @@
+import { Vector3 } from './Vector3.js';
+
+export class Ray {
+  origin: Vector3;
+  direction: Vector3;
+
+  constructor(origin = new Vector3(), direction = new Vector3(1, 0, 0)) {
+    this.origin = Vector3.clone(origin);
+    this.direction = Vector3.normalize(direction);
+  }
+
+  static getPoint(ray: Ray, distance: number, result = new Vector3()): Vector3 {
+    result.x = ray.origin.x + ray.direction.x * distance;
+    result.y = ray.origin.y + ray.direction.y * distance;
+    result.z = ray.origin.z + ray.direction.z * distance;
+    return result;
+  }
+}

--- a/src/math/Vector2.ts
+++ b/src/math/Vector2.ts
@@ -1,0 +1,59 @@
+export class Vector2 {
+  x: number;
+  y: number;
+
+  constructor(x = 0, y = 0) {
+    this.x = x;
+    this.y = y;
+  }
+
+  static create(x = 0, y = 0): Vector2 {
+    return new Vector2(x, y);
+  }
+
+  static clone(v: Vector2, result = new Vector2()): Vector2 {
+    result.x = v.x;
+    result.y = v.y;
+    return result;
+  }
+
+  static add(a: Vector2, b: Vector2, result = new Vector2()): Vector2 {
+    result.x = a.x + b.x;
+    result.y = a.y + b.y;
+    return result;
+  }
+
+  static subtract(a: Vector2, b: Vector2, result = new Vector2()): Vector2 {
+    result.x = a.x - b.x;
+    result.y = a.y - b.y;
+    return result;
+  }
+
+  static multiplyByScalar(v: Vector2, scalar: number, result = new Vector2()): Vector2 {
+    result.x = v.x * scalar;
+    result.y = v.y * scalar;
+    return result;
+  }
+
+  static dot(a: Vector2, b: Vector2): number {
+    return a.x * b.x + a.y * b.y;
+  }
+
+  static magnitude(v: Vector2): number {
+    return Math.sqrt(v.x * v.x + v.y * v.y);
+  }
+
+  static normalize(v: Vector2, result = new Vector2()): Vector2 {
+    const mag = Vector2.magnitude(v);
+    if (mag === 0) {
+      result.x = 0;
+      result.y = 0;
+      return result;
+    }
+    return Vector2.multiplyByScalar(v, 1.0 / mag, result);
+  }
+
+  static equalsEpsilon(a: Vector2, b: Vector2, epsilon = 1e-8): boolean {
+    return Math.abs(a.x - b.x) <= epsilon && Math.abs(a.y - b.y) <= epsilon;
+  }
+}

--- a/src/math/Vector3.ts
+++ b/src/math/Vector3.ts
@@ -1,0 +1,149 @@
+export class Vector3 {
+  x: number;
+  y: number;
+  z: number;
+
+  constructor(x = 0, y = 0, z = 0) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+
+  static create(x = 0, y = 0, z = 0): Vector3 {
+    return new Vector3(x, y, z);
+  }
+
+  static clone(v: Vector3, result = new Vector3()): Vector3 {
+    result.x = v.x;
+    result.y = v.y;
+    result.z = v.z;
+    return result;
+  }
+
+  static fromArray(array: ArrayLike<number>, offset = 0, result = new Vector3()): Vector3 {
+    result.x = array[offset];
+    result.y = array[offset + 1];
+    result.z = array[offset + 2];
+    return result;
+  }
+
+  static toArray(v: Vector3, result: number[] = [], offset = 0): number[] {
+    result[offset] = v.x;
+    result[offset + 1] = v.y;
+    result[offset + 2] = v.z;
+    return result;
+  }
+
+  static add(a: Vector3, b: Vector3, result = new Vector3()): Vector3 {
+    result.x = a.x + b.x;
+    result.y = a.y + b.y;
+    result.z = a.z + b.z;
+    return result;
+  }
+
+  static subtract(a: Vector3, b: Vector3, result = new Vector3()): Vector3 {
+    result.x = a.x - b.x;
+    result.y = a.y - b.y;
+    result.z = a.z - b.z;
+    return result;
+  }
+
+  static multiplyByScalar(v: Vector3, scalar: number, result = new Vector3()): Vector3 {
+    result.x = v.x * scalar;
+    result.y = v.y * scalar;
+    result.z = v.z * scalar;
+    return result;
+  }
+
+  static divideByScalar(v: Vector3, scalar: number, result = new Vector3()): Vector3 {
+    return Vector3.multiplyByScalar(v, 1.0 / scalar, result);
+  }
+
+  static negate(v: Vector3, result = new Vector3()): Vector3 {
+    result.x = -v.x;
+    result.y = -v.y;
+    result.z = -v.z;
+    return result;
+  }
+
+  static dot(a: Vector3, b: Vector3): number {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+  }
+
+  static cross(a: Vector3, b: Vector3, result = new Vector3()): Vector3 {
+    const ax = a.x;
+    const ay = a.y;
+    const az = a.z;
+    const bx = b.x;
+    const by = b.y;
+    const bz = b.z;
+    result.x = ay * bz - az * by;
+    result.y = az * bx - ax * bz;
+    result.z = ax * by - ay * bx;
+    return result;
+  }
+
+  static magnitude(v: Vector3): number {
+    return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+  }
+
+  static magnitudeSquared(v: Vector3): number {
+    return v.x * v.x + v.y * v.y + v.z * v.z;
+  }
+
+  static normalize(v: Vector3, result = new Vector3()): Vector3 {
+    const mag = Vector3.magnitude(v);
+    if (mag === 0) {
+      result.x = 0;
+      result.y = 0;
+      result.z = 0;
+      return result;
+    }
+    return Vector3.divideByScalar(v, mag, result);
+  }
+
+  static distance(a: Vector3, b: Vector3): number {
+    return Vector3.magnitude(Vector3.subtract(a, b, scratchVector));
+  }
+
+  static distanceSquared(a: Vector3, b: Vector3): number {
+    const dx = a.x - b.x;
+    const dy = a.y - b.y;
+    const dz = a.z - b.z;
+    return dx * dx + dy * dy + dz * dz;
+  }
+
+  static lerp(a: Vector3, b: Vector3, t: number, result = new Vector3()): Vector3 {
+    result.x = a.x + (b.x - a.x) * t;
+    result.y = a.y + (b.y - a.y) * t;
+    result.z = a.z + (b.z - a.z) * t;
+    return result;
+  }
+
+  static projectOnVector(vector: Vector3, onto: Vector3, result = new Vector3()): Vector3 {
+    const denom = Vector3.dot(onto, onto);
+    if (denom === 0) {
+      result.x = 0;
+      result.y = 0;
+      result.z = 0;
+      return result;
+    }
+    const scale = Vector3.dot(vector, onto) / denom;
+    return Vector3.multiplyByScalar(onto, scale, result);
+  }
+
+  static projectOnPlane(vector: Vector3, planeNormal: Vector3, result = new Vector3()): Vector3 {
+    const projection = Vector3.projectOnVector(vector, planeNormal, scratchVector);
+    return Vector3.subtract(vector, projection, result);
+  }
+
+  static equalsEpsilon(a: Vector3, b: Vector3, epsilon = 1e-10): boolean {
+    return (
+      Math.abs(a.x - b.x) <= epsilon &&
+      Math.abs(a.y - b.y) <= epsilon &&
+      Math.abs(a.z - b.z) <= epsilon
+    );
+  }
+}
+
+const scratchVector = new Vector3();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,114 @@
+import { Matrix4 } from './math/Matrix4.js';
+import { Quaternion } from './math/Quaternion.js';
+import { Vector3 } from './math/Vector3.js';
+
+export type Axis = 'x' | 'y' | 'z';
+export type Mode = 'translate' | 'rotate' | 'scale';
+export type Orientation = 'global' | 'local' | 'view' | 'enu' | 'normal' | 'gimbal';
+export type Pivot = 'origin' | 'median' | 'cursor' | 'individual';
+
+export interface SnapStepConfig {
+  translate: number;
+  rotate: number; // radians
+  scale: number;
+  fineModifier?: number;
+  coarseModifier?: number;
+}
+
+export interface SnapRuntimeOptions {
+  enabled: boolean;
+  fineModifierActive: boolean;
+  coarseModifierActive: boolean;
+}
+
+export interface ManipulatorOptions {
+  target?: TransformTarget | TransformTarget[];
+  orientation?: Orientation;
+  pivot?: Pivot;
+  enableTranslate?: boolean;
+  enableRotate?: boolean;
+  enableScale?: boolean;
+  snap?: SnapStepConfig;
+  size?: ManipulatorSizeOptions;
+  show?: boolean;
+}
+
+export interface ManipulatorSizeOptions {
+  screenPixelRadius: number;
+  minScale: number;
+  maxScale: number;
+}
+
+export interface TransformDelta {
+  translation: Vector3;
+  rotation: Quaternion;
+  scale: Vector3;
+}
+
+export interface DragContext {
+  mode: Mode;
+  axis?: Axis;
+  planeAxis?: [Axis, Axis];
+  handleId: string;
+  startPointer: { x: number; y: number };
+  startRayOrigin: Vector3;
+  startRayDirection: Vector3;
+  startMatrix: Matrix4;
+  pivotWorld: Vector3;
+  frame: FrameState;
+  currentDelta: TransformDelta;
+}
+
+export interface HandleVisualState {
+  id: string;
+  mode: Mode;
+  axis?: Axis;
+  planeAxis?: [Axis, Axis];
+  active: boolean;
+  highlighted: boolean;
+}
+
+export interface PickResult {
+  handleId: string;
+  mode: Mode;
+  axis?: Axis;
+  planeAxis?: [Axis, Axis];
+  distance: number;
+  screenPosition: { x: number; y: number };
+}
+
+export interface FrameState {
+  origin: Vector3;
+  axes: {
+    x: Vector3;
+    y: Vector3;
+    z: Vector3;
+  };
+  matrix: Matrix4;
+  inverse: Matrix4;
+}
+
+export interface TransformTarget {
+  readonly id: string;
+  getMatrix(result?: Matrix4): Matrix4;
+  setMatrix(matrix: Matrix4): void;
+}
+
+export interface TransformCommand {
+  id: string;
+  before: Matrix4;
+  after: Matrix4;
+}
+
+export interface CursorProvider {
+  getCursorPosition(): Vector3 | undefined;
+}
+
+export interface HudDisplayValues {
+  mode: Mode;
+  axisLabel: string;
+  deltaTranslation?: Vector3;
+  deltaRotation?: Vector3; // in radians
+  deltaScale?: Vector3;
+  snapped: boolean;
+}

--- a/src/utils/Geodesy.ts
+++ b/src/utils/Geodesy.ts
@@ -1,0 +1,55 @@
+import { Matrix3 } from '../math/Matrix3.js';
+import { Vector3 } from '../math/Vector3.js';
+
+const WGS84_A = 6378137.0;
+const WGS84_B = 6356752.3142451793;
+const WGS84_E2 = 1 - (WGS84_B * WGS84_B) / (WGS84_A * WGS84_A);
+
+export interface Cartographic {
+  longitude: number;
+  latitude: number;
+  height: number;
+}
+
+export function ecefToCartographic(position: Vector3): Cartographic {
+  const x = position.x;
+  const y = position.y;
+  const z = position.z;
+  const longitude = Math.atan2(y, x);
+  const p = Math.sqrt(x * x + y * y);
+  const theta = Math.atan2(z * WGS84_A, p * WGS84_B);
+  const sinTheta = Math.sin(theta);
+  const cosTheta = Math.cos(theta);
+  const latitude = Math.atan2(z + (WGS84_E2 * WGS84_B) * sinTheta * sinTheta * sinTheta, p - (WGS84_E2 * WGS84_A) * cosTheta * cosTheta * cosTheta);
+  const sinLat = Math.sin(latitude);
+  const N = WGS84_A / Math.sqrt(1 - WGS84_E2 * sinLat * sinLat);
+  const height = p / Math.cos(latitude) - N;
+  return { longitude, latitude, height };
+}
+
+export function eastNorthUpMatrix(origin: Vector3, result = new Matrix3()): Matrix3 {
+  const cartographic = ecefToCartographic(origin);
+  const lon = cartographic.longitude;
+  const lat = cartographic.latitude;
+
+  const cosLon = Math.cos(lon);
+  const sinLon = Math.sin(lon);
+  const cosLat = Math.cos(lat);
+  const sinLat = Math.sin(lat);
+
+  const east = new Vector3(-sinLon, cosLon, 0);
+  const north = new Vector3(-sinLat * cosLon, -sinLat * sinLon, cosLat);
+  const up = new Vector3(cosLat * cosLon, cosLat * sinLon, sinLat);
+
+  return result.setFromColumns(east, north, up);
+}
+
+export function enuAxes(origin: Vector3): { east: Vector3; north: Vector3; up: Vector3 } {
+  const matrix = eastNorthUpMatrix(origin);
+  const e = matrix.elements;
+  return {
+    east: new Vector3(e[0], e[1], e[2]),
+    north: new Vector3(e[3], e[4], e[5]),
+    up: new Vector3(e[6], e[7], e[8])
+  };
+}

--- a/src/utils/Transform.ts
+++ b/src/utils/Transform.ts
@@ -1,0 +1,44 @@
+import { Matrix3 } from '../math/Matrix3.js';
+import { Matrix4 } from '../math/Matrix4.js';
+import { Quaternion } from '../math/Quaternion.js';
+import { Vector3 } from '../math/Vector3.js';
+import { TransformDelta } from '../types.js';
+
+export function createIdentityDelta(): TransformDelta {
+  return {
+    translation: new Vector3(0, 0, 0),
+    rotation: Quaternion.identity(),
+    scale: new Vector3(1, 1, 1)
+  };
+}
+
+export function composeTransform(delta: TransformDelta, base: Matrix4, result = new Matrix4()): Matrix4 {
+  const translation = base.getTranslation(new Vector3());
+  const scale = base.getScale(new Vector3());
+  const rotationMatrix = base.getRotation(new Matrix3());
+  const baseRotation = Quaternion.fromRotationMatrix(rotationMatrix);
+
+  const combinedTranslation = Vector3.add(translation, delta.translation, new Vector3());
+  const combinedRotation = Quaternion.multiply(delta.rotation, baseRotation, new Quaternion());
+  const combinedScale = new Vector3(scale.x * delta.scale.x, scale.y * delta.scale.y, scale.z * delta.scale.z);
+
+  return Matrix4.fromTranslationRotationScale(combinedTranslation, combinedRotation, combinedScale, result);
+}
+
+export function decomposeMatrix(matrix: Matrix4): { translation: Vector3; rotation: Quaternion; scale: Vector3 } {
+  const translation = matrix.getTranslation(new Vector3());
+  const scale = matrix.getScale(new Vector3());
+  const rotationMatrix = matrix.getRotation(new Matrix3());
+  // Remove scaling from rotation matrix
+  rotationMatrix.elements[0] /= scale.x;
+  rotationMatrix.elements[1] /= scale.x;
+  rotationMatrix.elements[2] /= scale.x;
+  rotationMatrix.elements[3] /= scale.y;
+  rotationMatrix.elements[4] /= scale.y;
+  rotationMatrix.elements[5] /= scale.y;
+  rotationMatrix.elements[6] /= scale.z;
+  rotationMatrix.elements[7] /= scale.z;
+  rotationMatrix.elements[8] /= scale.z;
+  const rotation = Quaternion.fromRotationMatrix(rotationMatrix);
+  return { translation, rotation, scale };
+}

--- a/tests/pivotResolver.test.ts
+++ b/tests/pivotResolver.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PivotResolver } from '../src/core/PivotResolver.js';
+import { MatrixTransformTarget } from '../src/core/targets/MatrixTransformTarget.js';
+import { Matrix4 } from '../src/math/Matrix4.js';
+import { Quaternion } from '../src/math/Quaternion.js';
+import { Vector3 } from '../src/math/Vector3.js';
+
+function createMatrix(x: number, y: number, z: number): Matrix4 {
+  return Matrix4.fromTranslationRotationScale(new Vector3(x, y, z), Quaternion.identity(), new Vector3(1, 1, 1));
+}
+
+test('PivotResolver computes median pivot', () => {
+  const targets = [
+    new MatrixTransformTarget(createMatrix(0, 0, 0)),
+    new MatrixTransformTarget(createMatrix(10, 0, 0))
+  ];
+  const resolver = new PivotResolver();
+  const pivot = resolver.resolveManipulatorPivot('median', targets);
+  assert.deepEqual(Vector3.toArray(pivot), [5, 0, 0]);
+});
+
+test('PivotResolver median per target map uses shared pivot', () => {
+  const targets = [
+    new MatrixTransformTarget(createMatrix(0, 0, 0)),
+    new MatrixTransformTarget(createMatrix(4, 0, 0))
+  ];
+  const resolver = new PivotResolver();
+  const manipPivot = resolver.resolveManipulatorPivot('median', targets);
+  const map = resolver.resolvePerTargetPivot('median', targets, manipPivot);
+  for (const pivot of map.values()) {
+    assert.deepEqual(Vector3.toArray(pivot), Vector3.toArray(manipPivot));
+  }
+});
+
+test('PivotResolver individual uses object origin', () => {
+  const targets = [
+    new MatrixTransformTarget(createMatrix(0, 0, 0)),
+    new MatrixTransformTarget(createMatrix(4, 0, 0))
+  ];
+  const resolver = new PivotResolver();
+  const manipPivot = resolver.resolveManipulatorPivot('individual', targets);
+  const map = resolver.resolvePerTargetPivot('individual', targets, manipPivot);
+  assert.deepEqual(Vector3.toArray(map.get(targets[0].id)!), [0, 0, 0]);
+  assert.deepEqual(Vector3.toArray(map.get(targets[1].id)!), [4, 0, 0]);
+});

--- a/tests/transformSolver.test.ts
+++ b/tests/transformSolver.test.ts
@@ -1,0 +1,259 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { TransformSolver } from '../src/core/TransformSolver.js';
+import { Snapper } from '../src/core/Snapper.js';
+import { Matrix4 } from '../src/math/Matrix4.js';
+import { Quaternion } from '../src/math/Quaternion.js';
+import { Vector3 } from '../src/math/Vector3.js';
+import { createPerspectiveCamera } from '../src/core/CameraState.js';
+import { SnapRuntimeOptions, DragContext, FrameState, Mode, Axis } from '../src/types.js';
+import { Ray } from '../src/math/Ray.js';
+
+function createFrame(): FrameState {
+  const origin = new Vector3(0, 0, 0);
+  const axes = {
+    x: new Vector3(1, 0, 0),
+    y: new Vector3(0, 1, 0),
+    z: new Vector3(0, 0, 1)
+  };
+  const matrix = Matrix4.fromColumns(axes.x, axes.y, axes.z, origin, new Matrix4());
+  const inverse = matrix.clone(new Matrix4()).invert();
+  return { origin, axes, matrix, inverse };
+}
+
+const snapOptions: SnapRuntimeOptions = {
+  enabled: false,
+  fineModifierActive: false,
+  coarseModifierActive: false
+};
+
+function createContext(mode: Mode, axis?: Axis, planeAxis?: [Axis, Axis]): DragContext {
+  const frame = createFrame();
+  return {
+    mode,
+    axis,
+    planeAxis,
+    handleId: planeAxis ? `${mode}-${planeAxis.join('')}` : axis ? `${mode}-${axis}` : `${mode}-free`,
+    startPointer: { x: 0, y: 0 },
+    startRayOrigin: new Vector3(),
+    startRayDirection: new Vector3(),
+    startMatrix: Matrix4.identity(),
+    pivotWorld: new Vector3(0, 0, 0),
+    frame,
+    currentDelta: {
+      translation: new Vector3(),
+      rotation: Quaternion.identity(),
+      scale: new Vector3(1, 1, 1)
+    }
+  };
+}
+
+test('TransformSolver resolves axis translation', () => {
+  const solver = new TransformSolver(new Snapper());
+  const frame = createFrame();
+  const camera = createPerspectiveCamera({
+    position: new Vector3(0, 0, 10),
+    lookAt: new Vector3(0, 0, 0),
+    viewportWidth: 800,
+    viewportHeight: 600,
+    aspect: 800 / 600
+  });
+  const startRay = new Ray(new Vector3(0, 0, 10), new Vector3(0, 0, -1));
+  const context = createContext('translate', 'x');
+  solver.beginDrag({
+    mode: 'translate',
+    axis: 'x',
+    frame,
+    pivotWorld: new Vector3(0, 0, 0),
+    startRay,
+    camera,
+    snapOptions
+  });
+  const newDirection = Vector3.normalize(new Vector3(2, 0, -10));
+  const newRay = new Ray(new Vector3(0, 0, 10), newDirection);
+  const delta = solver.updateDrag(context, { currentRay: newRay, snapOptions });
+  assert.ok(Math.abs(delta.translation.x + 2) < 1e-5);
+  assert.ok(Math.abs(delta.translation.y) < 1e-5);
+});
+
+test('TransformSolver resolves plane translation on XY', () => {
+  const solver = new TransformSolver(new Snapper());
+  const frame = createFrame();
+  const camera = createPerspectiveCamera({
+    position: new Vector3(0, 0, 10),
+    lookAt: new Vector3(0, 0, 0),
+    viewportWidth: 800,
+    viewportHeight: 600,
+    aspect: 800 / 600
+  });
+  const pivot = new Vector3(0, 0, 0);
+  const startRay = new Ray(new Vector3(0, 0, 10), new Vector3(0, 0, -1));
+  solver.beginDrag({
+    mode: 'translate',
+    planeAxis: ['x', 'y'],
+    frame,
+    pivotWorld: pivot,
+    startRay,
+    camera,
+    snapOptions
+  });
+  const context = createContext('translate', undefined, ['x', 'y']);
+  const newDirection = Vector3.normalize(new Vector3(1, 1, -5));
+  const newRay = new Ray(new Vector3(0, 0, 10), newDirection);
+  const delta = solver.updateDrag(context, { currentRay: newRay, snapOptions });
+  const startPoint = intersectRayPlane(startRay, pivot, new Vector3(0, 0, 1));
+  const newPoint = intersectRayPlane(newRay, pivot, new Vector3(0, 0, 1));
+  const expected = Vector3.subtract(newPoint, startPoint, new Vector3());
+  assert.ok(Math.abs(delta.translation.x - expected.x) < 1e-5);
+  assert.ok(Math.abs(delta.translation.y - expected.y) < 1e-5);
+  assert.ok(Math.abs(delta.translation.z - expected.z) < 1e-5);
+});
+
+test('TransformSolver resolves rotation around Z', () => {
+  const solver = new TransformSolver(new Snapper());
+  const frame = createFrame();
+  const camera = createPerspectiveCamera({
+    position: new Vector3(0, 0, 10),
+    lookAt: new Vector3(0, 0, 0),
+    viewportWidth: 800,
+    viewportHeight: 600,
+    aspect: 800 / 600
+  });
+  const startRay = new Ray(new Vector3(0, 0, 10), Vector3.normalize(new Vector3(1, 0, -10)));
+  solver.beginDrag({
+    mode: 'rotate',
+    axis: 'z',
+    frame,
+    pivotWorld: new Vector3(0, 0, 0),
+    startRay,
+    camera,
+    snapOptions
+  });
+  const context = createContext('rotate', 'z');
+  const newRay = new Ray(new Vector3(0, 0, 10), Vector3.normalize(new Vector3(0, 1, -10)));
+  const delta = solver.updateDrag(context, { currentRay: newRay, snapOptions });
+  const euler = delta.rotation.toEuler(new Vector3());
+  assert.ok(Math.abs(euler.z - Math.PI / 2) < 0.1);
+});
+
+test('TransformSolver resolves view-aligned rotation', () => {
+  const solver = new TransformSolver(new Snapper());
+  const frame = createFrame();
+  const camera = createPerspectiveCamera({
+    position: new Vector3(0, 0, 10),
+    lookAt: new Vector3(0, 0, 0),
+    viewportWidth: 800,
+    viewportHeight: 600,
+    aspect: 800 / 600
+  });
+  const pivot = new Vector3(0, 0, 0);
+  const startRay = new Ray(new Vector3(0, 0, 10), Vector3.normalize(new Vector3(1, 0, -10)));
+  solver.beginDrag({
+    mode: 'rotate',
+    frame,
+    pivotWorld: pivot,
+    startRay,
+    camera,
+    snapOptions
+  });
+  const context = createContext('rotate');
+  const newRay = new Ray(new Vector3(0, 0, 10), Vector3.normalize(new Vector3(0, 1, -10)));
+  const delta = solver.updateDrag(context, { currentRay: newRay, snapOptions });
+  const signed = extractSignedAngle(delta.rotation, camera.direction);
+  assert.ok(Math.abs(signed + Math.PI / 2) < 0.1);
+});
+
+test('TransformSolver resolves uniform scale', () => {
+  const solver = new TransformSolver(new Snapper());
+  const frame = createFrame();
+  const camera = createPerspectiveCamera({
+    position: new Vector3(0, 0, 10),
+    lookAt: new Vector3(0, 0, 0),
+    viewportWidth: 800,
+    viewportHeight: 600,
+    aspect: 800 / 600
+  });
+  const startRay = new Ray(new Vector3(0, 0, 10), new Vector3(0, 0, -1));
+  solver.beginDrag({
+    mode: 'scale',
+    frame,
+    pivotWorld: new Vector3(0, 0, 0),
+    startRay,
+    camera,
+    snapOptions
+  });
+  const context = createContext('scale', 'x');
+  const newRay = new Ray(new Vector3(0, 0, 10), new Vector3(0, 0, -1));
+  const delta = solver.updateDrag(context, { currentRay: newRay, snapOptions });
+  assert.ok(Math.abs(delta.scale.x - 1) < 1e-5);
+});
+
+test('TransformSolver resolves negative axis scale', () => {
+  const solver = new TransformSolver(new Snapper());
+  const frame = createFrame();
+  const camera = createPerspectiveCamera({
+    position: new Vector3(0, 0, 10),
+    lookAt: new Vector3(0, 0, 0),
+    viewportWidth: 800,
+    viewportHeight: 600,
+    aspect: 800 / 600
+  });
+  const pivot = new Vector3(0, 0, 0);
+  const startRay = new Ray(new Vector3(0, 0, 10), new Vector3(0, 0, -1));
+  solver.beginDrag({
+    mode: 'scale',
+    axis: 'x',
+    frame,
+    pivotWorld: pivot,
+    startRay,
+    camera,
+    snapOptions
+  });
+  const context = createContext('scale', 'x');
+  const newDirection = Vector3.normalize(new Vector3(3, 0, -10));
+  const newRay = new Ray(new Vector3(0, 0, 10), newDirection);
+  const delta = solver.updateDrag(context, { currentRay: newRay, snapOptions });
+  const startParam = projectRayToAxis(startRay, pivot, frame.axes.x);
+  const currentParam = projectRayToAxis(newRay, pivot, frame.axes.x);
+  const expectedScale = 1 + (currentParam - startParam);
+  assert.ok(delta.scale.x < 0);
+  assert.ok(Math.abs(delta.scale.x - expectedScale) < 1e-5);
+});
+
+function intersectRayPlane(ray: Ray, pointOnPlane: Vector3, planeNormal: Vector3): Vector3 {
+  const denom = Vector3.dot(planeNormal, ray.direction);
+  if (Math.abs(denom) < 1e-8) {
+    return new Vector3(pointOnPlane.x, pointOnPlane.y, pointOnPlane.z);
+  }
+  const diff = Vector3.subtract(pointOnPlane, ray.origin, new Vector3());
+  const t = Vector3.dot(planeNormal, diff) / denom;
+  const offset = Vector3.multiplyByScalar(ray.direction, t, new Vector3());
+  return Vector3.add(ray.origin, offset, new Vector3());
+}
+
+function extractSignedAngle(quaternion: Quaternion, referenceAxis: Vector3): number {
+  const sinHalf = Math.sqrt(quaternion.x * quaternion.x + quaternion.y * quaternion.y + quaternion.z * quaternion.z);
+  if (sinHalf < 1e-8) {
+    return 0;
+  }
+  const axis = Vector3.normalize(new Vector3(quaternion.x, quaternion.y, quaternion.z));
+  let angle = 2 * Math.atan2(sinHalf, quaternion.w);
+  if (Vector3.dot(axis, referenceAxis) < 0) {
+    angle = -angle;
+  }
+  return angle;
+}
+
+function projectRayToAxis(ray: Ray, origin: Vector3, axis: Vector3): number {
+  const w0 = Vector3.subtract(ray.origin, origin, new Vector3());
+  const a = Vector3.dot(axis, axis);
+  const b = Vector3.dot(axis, ray.direction);
+  const c = Vector3.dot(ray.direction, ray.direction);
+  const d = Vector3.dot(axis, w0);
+  const e = Vector3.dot(ray.direction, w0);
+  const denom = a * c - b * b;
+  if (Math.abs(denom) < 1e-12) {
+    return Vector3.dot(axis, w0);
+  }
+  return (b * e - c * d) / denom;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": ".",
+    "outDir": "dist",
+    "types": [],
+    "useDefineForClassFields": true
+  },
+  "include": ["src/**/*", "example/**/*", "tests/**/*", "types/**/*.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/types/node.d.ts
+++ b/types/node.d.ts
@@ -1,0 +1,10 @@
+declare module 'node:test' {
+  type TestFn = (t: unknown) => void | Promise<void>;
+  const test: (name: string, fn: TestFn) => void;
+  export default test;
+}
+
+declare module 'node:assert/strict' {
+  const assert: typeof import('assert');
+  export default assert;
+}


### PR DESCRIPTION
## Summary
- extend `TransformSolver` unit coverage to include plane translation, view-axis rotation, and negative scaling scenarios
- add shared helpers in the tests for ray-plane intersection, signed angle extraction, and ray-axis projection comparisons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d010a46ae4832db2a64971778e94f8