### PR TITLE
Add Cesium universal manipulator library and demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
-# cesium-gizmo-demo
+# Cesium Universal Manipulator Demo
+
+This project delivers a reusable universal manipulator for CesiumJS scenes, providing translation, rotation, and scaling handles with configurable orientation, pivot modes, snapping, and live HUD feedback. It also includes a sample Cesium application and deterministic math-focused unit tests.
+
+## Features
+
+- Unified translate / rotate / scale gizmo with per-mode visibility controls.
+- Supports `Orientation = global | local | view | enu | normal | gimbal`.
+- Supports `Pivot = origin | median | cursor | individual`.
+- Snap system for translation / rotation / scale with fine-step modifiers.
+- Math utilities (Vector3, Quaternion, Matrix4) with stable TRS decomposition.
+- Event controller with hover / drag states, ESC cancellation, and HUD feedback.
+- Example Cesium page demonstrating orientation & pivot switching.
+
+## Getting started
+
+### Prerequisites
+
+- Node.js ≥ 18 (ships with TypeScript compiler in this environment).
+- Internet access when running the demo (loads Cesium assets from CDN).
+
+### Build & test
+
+```bash
+npm run build
+npm test
+```
+
+`npm run build` transpiles TypeScript to the `dist` directory. `npm test` recompiles and executes the bespoke unit tests in `dist/tests/run-tests.js`.
+
+### Run the example
+
+1. Build the project (`npm run build`).
+2. Open `public/index.html` in a browser.
+3. The page loads CesiumJS 1.118 via CDN and the manipulator bundle from `dist/src/example/main.js`.
+4. Use the toolbar to change orientation/pivot and toggle translation/rotation/scale handles.
+
+## Library usage
+
+Import the primary class:
+
+```ts
+import { UniversalManipulator } from 'cesium-gizmo-demo';
+```
+
+Instantiate with a Cesium `Viewer` and your target object (any object exposing a `matrix` property with 16 column-major elements is supported; `position`/`rotation`/`scale` are populated automatically).
+
+```ts
+const manipulator = new UniversalManipulator(viewer, {
+  target: myTarget,
+  orientation: 'enu',
+  pivot: 'origin',
+  snap: {
+    translateStep: 1,
+    rotateStep: Cesium.Math.toRadians(5),
+    scaleStep: 0.1
+  }
+});
+```
+
+### API surface
+
+- `setTarget(target | target[])`
+- `setOrientation(orientation)`
+- `setPivot(pivot)`
+- `enable({ translate?, rotate?, scale? })`
+- `setSnap(stepConfig)`
+- `setSize(screenPixelRadius, minScale?, maxScale?)`
+- `setCursor(cursorState)`
+- `destroy()`
+
+Additional utilities are exported from `src/index.ts` (math helpers, solver, picker, etc.).
+
+## Tests
+
+The unit suite in `tests/run-tests.ts` covers:
+
+- Axis & plane translation solvers
+- Axis & view-plane rotation solvers
+- Axis scaling solver
+
+Each assertion enforces a tolerance of `1e-5` or tighter.
+
+## Notes & limitations
+
+- The sample adapter expects targets to expose a mutable `matrix` field. For Cesium `Entity` or `Model` instances, wrap them in a `TargetLike` object that synchronises `matrix` back into the engine each frame (see `src/example/main.ts`).
+- The manipulator draws using Cesium primitives placed in a `CustomDataSource`; depth testing is disabled so the gizmo always renders on top.
+- The math tests run in Node and do not rely on Cesium; the demo requires a browser.
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cesium-gizmo-demo",
+  "version": "1.0.0",
+  "description": "Universal manipulator for Cesium demo",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --experimental-specifier-resolution=node dist/tests/run-tests.js",
+    "check": "npm run build"
+  },
+  "keywords": ["cesium", "manipulator", "gizmo"],
+  "author": "",
+  "license": "MIT"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cesium Universal Manipulator Demo</title>
+    <link
+      rel="stylesheet"
+      href="https://cesium.com/downloads/cesiumjs/releases/1.118/Build/Cesium/Widgets/widgets.css"
+    />
+    <style>
+      html,
+      body,
+      #cesiumContainer {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+      }
+      .toolbar {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        background: rgba(0, 0, 0, 0.6);
+        color: #fff;
+        padding: 10px;
+        border-radius: 6px;
+        font-family: sans-serif;
+        z-index: 1;
+      }
+      .toolbar label {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 12px;
+      }
+      .toolbar select,
+      .toolbar input[type='checkbox'] {
+        margin-left: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="cesiumContainer"></div>
+    <div class="toolbar">
+      <label>
+        Orientation
+        <select id="orientation">
+          <option value="global">Global</option>
+          <option value="local">Local</option>
+          <option value="view">View</option>
+          <option value="enu" selected>ENU</option>
+          <option value="normal">Normal</option>
+          <option value="gimbal">Gimbal</option>
+        </select>
+      </label>
+      <label>
+        Pivot
+        <select id="pivot">
+          <option value="origin" selected>Origin</option>
+          <option value="median">Median</option>
+          <option value="cursor">Cursor</option>
+          <option value="individual">Individual</option>
+        </select>
+      </label>
+      <label>
+        <input type="checkbox" id="enable-translate" checked /> Translate
+      </label>
+      <label>
+        <input type="checkbox" id="enable-rotate" checked /> Rotate
+      </label>
+      <label>
+        <input type="checkbox" id="enable-scale" checked /> Scale
+      </label>
+    </div>
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.118/Build/Cesium/Cesium.js"></script>
+    <script type="module" src="../dist/src/example/main.js"></script>
+  </body>
+</html>

--- a/src/core/CommandStack.ts
+++ b/src/core/CommandStack.ts
@@ -1,0 +1,32 @@
+import { CommandStack as CommandStackInterface, TransformCommand } from './types.js';
+
+export class CommandStack implements CommandStackInterface {
+  private stack: TransformCommand[] = [];
+  private redoStack: TransformCommand[] = [];
+
+  push(command: TransformCommand): void {
+    this.stack.push(command);
+    this.redoStack = [];
+  }
+
+  undo(): TransformCommand | undefined {
+    const command = this.stack.pop();
+    if (command) {
+      this.redoStack.push(command);
+    }
+    return command;
+  }
+
+  redo(): TransformCommand | undefined {
+    const command = this.redoStack.pop();
+    if (command) {
+      this.stack.push(command);
+    }
+    return command;
+  }
+
+  clear(): void {
+    this.stack = [];
+    this.redoStack = [];
+  }
+}

--- a/src/core/FrameBuilder.ts
+++ b/src/core/FrameBuilder.ts
@@ -1,0 +1,153 @@
+import { Orientation, TargetLike, FrameState, CameraInfo } from './types.js';
+import { Matrix4 } from '../utils/math/Matrix4.js';
+import { Quaternion } from '../utils/math/Quaternion.js';
+import { Vector3 } from '../utils/math/Vector3.js';
+import { eastNorthUp } from '../utils/geodesy.js';
+
+export interface FrameBuilderOptions {
+  orientation: Orientation;
+  targets: TargetLike[];
+  pivot: [number, number, number];
+  camera?: CameraInfo;
+  surfaceNormal?: [number, number, number];
+}
+
+function basisFromQuaternion(q: Quaternion): { x: Vector3; y: Vector3; z: Vector3 } {
+  const matrix = q.toMatrix3();
+  const x = new Vector3(matrix[0], matrix[3], matrix[6]).normalize();
+  const y = new Vector3(matrix[1], matrix[4], matrix[7]).normalize();
+  const z = new Vector3(matrix[2], matrix[5], matrix[8]).normalize();
+  return { x, y, z };
+}
+
+function defaultTargetMatrix(target: TargetLike): Matrix4 {
+  if (target.matrix) {
+    return Matrix4.fromArray(target.matrix);
+  }
+  const position = target.position ? Vector3.fromArray(target.position) : Vector3.zero();
+  const rotation = target.rotation
+    ? new Quaternion(target.rotation[0], target.rotation[1], target.rotation[2], target.rotation[3])
+    : Quaternion.identity();
+  const scale = target.scale ? Vector3.fromArray(target.scale) : new Vector3(1, 1, 1);
+  return Matrix4.fromTranslationRotationScale(position, rotation, scale);
+}
+
+function ensureOrthonormal(x: Vector3, y: Vector3, z: Vector3): { x: Vector3; y: Vector3; z: Vector3 } {
+  const zNorm = z.normalize();
+  const xOrtho = Vector3.rejectFromVector(x, zNorm).normalize();
+  const yOrtho = zNorm.cross(xOrtho).normalize();
+  return { x: xOrtho, y: yOrtho, z: zNorm };
+}
+
+export class FrameBuilder {
+  constructor(private options: FrameBuilderOptions) {}
+
+  build(): FrameState {
+    const pivot = Vector3.fromArray(this.options.pivot);
+    const orientation = this.options.orientation;
+    const targets = this.options.targets;
+    const camera = this.options.camera;
+    const normal = this.options.surfaceNormal
+      ? Vector3.fromArray(this.options.surfaceNormal).normalize()
+      : undefined;
+
+    let axes: { x: Vector3; y: Vector3; z: Vector3 };
+
+    switch (orientation) {
+      case 'global':
+        axes = {
+          x: new Vector3(1, 0, 0),
+          y: new Vector3(0, 1, 0),
+          z: new Vector3(0, 0, 1)
+        };
+        break;
+      case 'local': {
+        const primary = targets[0];
+        const matrix = defaultTargetMatrix(primary);
+        const rotation = matrix.getRotation();
+        axes = basisFromQuaternion(rotation);
+        break;
+      }
+      case 'view': {
+        if (!camera) {
+          throw new Error('View orientation requires camera info');
+        }
+        axes = {
+          x: Vector3.fromArray(camera.right).normalize(),
+          y: Vector3.fromArray(camera.up).normalize(),
+          z: Vector3.fromArray(camera.direction).multiplyByScalar(-1).normalize()
+        };
+        break;
+      }
+      case 'enu': {
+        const basis = eastNorthUp(pivot);
+        axes = {
+          x: basis.east,
+          y: basis.north,
+          z: basis.up
+        };
+        break;
+      }
+      case 'normal': {
+        if (!normal) {
+          throw new Error('Normal orientation requires surface normal');
+        }
+        const upReference = camera
+          ? Vector3.fromArray(camera.up).normalize()
+          : new Vector3(0, 0, 1);
+        let xAxis = upReference.cross(normal);
+        if (xAxis.length() < 1e-6) {
+          xAxis = new Vector3(1, 0, 0).cross(normal);
+        }
+        const zAxis = normal.normalize();
+        const yAxis = zAxis.cross(xAxis).normalize();
+        axes = ensureOrthonormal(xAxis, yAxis, zAxis);
+        break;
+      }
+      case 'gimbal': {
+        const primary = targets[0];
+        const matrix = defaultTargetMatrix(primary);
+        const rotation = matrix.getRotation();
+        const localBasis = basisFromQuaternion(rotation);
+        const up = camera
+          ? Vector3.fromArray(camera.up).normalize()
+          : eastNorthUp(pivot).up;
+        let xAxis = Vector3.rejectFromVector(localBasis.x, up);
+        if (xAxis.length() < 1e-6) {
+          xAxis = Vector3.rejectFromVector(localBasis.y, up);
+        }
+        if (xAxis.length() < 1e-6) {
+          xAxis = new Vector3(1, 0, 0);
+        }
+        const zAxis = localBasis.z;
+        const yAxis = zAxis.cross(xAxis).normalize();
+        axes = ensureOrthonormal(xAxis, yAxis, zAxis);
+        break;
+      }
+      default:
+        axes = {
+          x: new Vector3(1, 0, 0),
+          y: new Vector3(0, 1, 0),
+          z: new Vector3(0, 0, 1)
+        };
+        break;
+    }
+
+    const matrix = new Matrix4([
+      axes.x.x, axes.y.x, axes.z.x, 0,
+      axes.x.y, axes.y.y, axes.z.y, 0,
+      axes.x.z, axes.y.z, axes.z.z, 0,
+      pivot.x, pivot.y, pivot.z, 1
+    ]);
+
+    return {
+      pivot: pivot.toArray(),
+      axes: {
+        x: axes.x.toArray(),
+        y: axes.y.toArray(),
+        z: axes.z.toArray()
+      },
+      matrix: matrix.elements
+    };
+  }
+}

--- a/src/core/GizmoPicker.ts
+++ b/src/core/GizmoPicker.ts
@@ -1,0 +1,67 @@
+import { GizmoPrimitive } from './GizmoPrimitive.js';
+import { HandleHit } from './types.js';
+
+const PRIORITY: Record<string, number> = {
+  'translate-axis': 3,
+  'scale-axis': 3,
+  'rotate-axis': 2,
+  'translate-plane': 1,
+  'rotate-view': 1,
+  'scale-uniform': 2
+};
+
+function getCesium(): any {
+  const Cesium = (globalThis as any).Cesium;
+  if (!Cesium) {
+    throw new Error('Cesium global is required for GizmoPicker');
+  }
+  return Cesium;
+}
+
+interface GizmoPickerOptions {
+  viewer: any;
+  gizmo: GizmoPrimitive;
+}
+
+export class GizmoPicker {
+  private viewer: any;
+  private gizmo: GizmoPrimitive;
+  private handleMap = new Map<any, ReturnType<GizmoPrimitive['getHandleDefinitions']>[number]>();
+
+  constructor(options: GizmoPickerOptions) {
+    this.viewer = options.viewer;
+    this.gizmo = options.gizmo;
+    this.syncHandles();
+  }
+
+  private syncHandles(): void {
+    this.handleMap.clear();
+    this.gizmo.getHandleDefinitions().forEach((handle) => {
+      this.handleMap.set(handle.entity, handle);
+      if (handle.entity && handle.entity.id) {
+        this.handleMap.set(handle.entity.id, handle);
+      }
+    });
+  }
+
+  pick(windowPosition: { x: number; y: number }): HandleHit | undefined {
+    const Cesium = getCesium();
+    const picked = this.viewer.scene.pick(windowPosition);
+    if (!picked) {
+      return undefined;
+    }
+    const handle = this.handleMap.get(picked.id) || this.handleMap.get(picked.primitive) || this.handleMap.get(picked);
+    if (!handle) {
+      return undefined;
+    }
+    return {
+      id: handle.id,
+      mode: handle.mode,
+      axis: handle.axis,
+      planeAxes: handle.planeAxes,
+      uniformScale: handle.uniformScale,
+      priority: PRIORITY[handle.type] || 0,
+      screenPosition: windowPosition
+    };
+  }
+}

--- a/src/core/GizmoPrimitive.ts
+++ b/src/core/GizmoPrimitive.ts
@@ -1,0 +1,401 @@
+import { FrameState, Axis, Mode } from './types.js';
+import { Vector3 } from '../utils/math/Vector3.js';
+
+type HandleType =
+  | 'translate-axis'
+  | 'translate-plane'
+  | 'rotate-axis'
+  | 'rotate-view'
+  | 'scale-axis'
+  | 'scale-uniform';
+
+interface HandleDefinition {
+  id: string;
+  type: HandleType;
+  mode: Mode;
+  axis?: Axis;
+  planeAxes?: [Axis, Axis];
+  uniformScale?: boolean;
+  color: string;
+  entity: any;
+}
+
+interface GizmoPrimitiveOptions {
+  viewer: any;
+  screenPixelRadius: number;
+  minScale: number;
+  maxScale: number;
+}
+
+function getCesium(): any {
+  const Cesium = (globalThis as any).Cesium;
+  if (!Cesium) {
+    throw new Error('Cesium global is required for GizmoPrimitive');
+  }
+  return Cesium;
+}
+
+function axisVector(frame: FrameState, axis: Axis): Vector3 {
+  const arr = frame.axes[axis];
+  return Vector3.fromArray(arr).normalize();
+}
+
+function toCartesian(array: [number, number, number]): any {
+  const Cesium = getCesium();
+  return new Cesium.Cartesian3(array[0], array[1], array[2]);
+}
+
+function computeScale(options: GizmoPrimitiveOptions, frame: FrameState): number {
+  const Cesium = getCesium();
+  const viewer = options.viewer;
+  const pivot = toCartesian(frame.pivot);
+  const camera = viewer.camera;
+  const position = camera.positionWC || camera.position;
+  const distance = Cesium.Cartesian3.distance(position, pivot);
+  let fovy = camera.frustum && camera.frustum.fovy ? camera.frustum.fovy : camera.frustum.fov;
+  if (!fovy) {
+    fovy = Cesium.Math.toRadians(60);
+  }
+  const canvasHeight = viewer.scene.canvas.height || 1080;
+  const metersPerPixel = (2 * distance * Math.tan(fovy / 2)) / canvasHeight;
+  const raw = metersPerPixel * options.screenPixelRadius;
+  return Cesium.Math.clamp(raw, options.minScale, options.maxScale);
+}
+
+function generateCirclePoints(
+  pivot: Vector3,
+  axis: Vector3,
+  radius: number,
+  segments: number
+): any[] {
+  const Cesium = getCesium();
+  const normalized = axis.normalize();
+  let reference = Math.abs(normalized.x) < 0.9 ? new Vector3(1, 0, 0) : new Vector3(0, 1, 0);
+  reference = Vector3.rejectFromVector(reference, normalized).normalize();
+  const binormal = normalized.cross(reference).normalize();
+  const points: any[] = [];
+  for (let i = 0; i <= segments; i++) {
+    const angle = (i / segments) * Math.PI * 2;
+    const dir = reference.multiplyByScalar(Math.cos(angle)).add(binormal.multiplyByScalar(Math.sin(angle)));
+    const position = pivot.add(dir.multiplyByScalar(radius));
+    points.push(new Cesium.Cartesian3(position.x, position.y, position.z));
+  }
+  return points;
+}
+
+export class GizmoPrimitive {
+  private viewer: any;
+  private options: GizmoPrimitiveOptions;
+  private handles: HandleDefinition[] = [];
+  private frame?: FrameState;
+  private show = true;
+  private highlightId?: string;
+  private activeId?: string;
+  private modeVisibility: Record<Mode, boolean> = {
+    translate: true,
+    rotate: true,
+    scale: true
+  };
+
+  constructor(options: GizmoPrimitiveOptions) {
+    this.viewer = options.viewer;
+    this.options = options;
+    this.createHandles();
+  }
+
+  private createHandles(): void {
+    const Cesium = getCesium();
+    const dataSource = new Cesium.CustomDataSource('gizmo');
+    this.viewer.dataSources.add(dataSource);
+
+    const addHandle = (definition: Omit<HandleDefinition, 'entity'>) => {
+      const entity = dataSource.entities.add({
+        id: definition.id,
+        show: this.show && this.modeVisibility[definition.mode]
+      });
+      const handle: HandleDefinition = { ...definition, entity };
+      this.handles.push(handle);
+    };
+
+    const axisIds: Axis[] = ['x', 'y', 'z'];
+
+    axisIds.forEach((axis) => {
+      addHandle({
+        id: `translate-axis-${axis}`,
+        type: 'translate-axis',
+        mode: 'translate',
+        axis,
+        color: axis,
+        planeAxes: undefined,
+        uniformScale: false
+      });
+      addHandle({
+        id: `rotate-axis-${axis}`,
+        type: 'rotate-axis',
+        mode: 'rotate',
+        axis,
+        color: axis,
+        planeAxes: undefined,
+        uniformScale: false
+      });
+      addHandle({
+        id: `scale-axis-${axis}`,
+        type: 'scale-axis',
+        mode: 'scale',
+        axis,
+        color: axis,
+        planeAxes: undefined,
+        uniformScale: false
+      });
+    });
+
+    addHandle({
+      id: 'translate-plane-xy',
+      type: 'translate-plane',
+      mode: 'translate',
+      planeAxes: ['x', 'y'],
+      color: 'xy',
+      uniformScale: false
+    });
+    addHandle({
+      id: 'translate-plane-yz',
+      type: 'translate-plane',
+      mode: 'translate',
+      planeAxes: ['y', 'z'],
+      color: 'yz',
+      uniformScale: false
+    });
+    addHandle({
+      id: 'translate-plane-xz',
+      type: 'translate-plane',
+      mode: 'translate',
+      planeAxes: ['x', 'z'],
+      color: 'xz',
+      uniformScale: false
+    });
+
+    addHandle({
+      id: 'rotate-view',
+      type: 'rotate-view',
+      mode: 'rotate',
+      color: 'white',
+      uniformScale: false
+    });
+
+    addHandle({
+      id: 'scale-uniform',
+      type: 'scale-uniform',
+      mode: 'scale',
+      color: 'white',
+      uniformScale: true
+    });
+  }
+
+  setShow(show: boolean): void {
+    this.show = show;
+    this.updateVisibility();
+  }
+
+  setFrame(frame: FrameState): void {
+    this.frame = frame;
+    this.updateGeometry();
+  }
+
+  updateSize(params: { screenPixelRadius?: number; minScale?: number; maxScale?: number }): void {
+    this.options = {
+      ...this.options,
+      screenPixelRadius: params.screenPixelRadius ?? this.options.screenPixelRadius,
+      minScale: params.minScale ?? this.options.minScale,
+      maxScale: params.maxScale ?? this.options.maxScale
+    };
+    if (this.frame) {
+      this.updateGeometry();
+    }
+  }
+
+  setModeVisibility(visibility: Partial<Record<Mode, boolean>>): void {
+    this.modeVisibility = {
+      ...this.modeVisibility,
+      ...visibility
+    } as Record<Mode, boolean>;
+    this.updateVisibility();
+  }
+
+  setHighlight(handleId?: string, active = false): void {
+    this.highlightId = handleId;
+    this.activeId = active ? handleId : this.activeId;
+    this.applyVisualState();
+  }
+
+  private applyVisualState(): void {
+    const Cesium = getCesium();
+    this.handles.forEach((handle) => {
+      const baseColor = this.resolveColor(handle.color, handle.axis);
+      let color = baseColor;
+      if (handle.id === this.activeId) {
+        color = this.getActiveColor(baseColor);
+      } else if (handle.id === this.highlightId) {
+        color = this.getHoverColor(baseColor);
+      }
+      if (handle.entity.polyline) {
+        handle.entity.polyline.material = color;
+      }
+      if (handle.entity.polygon) {
+        const alphaColor = this.withAlpha(color, 0.3);
+        handle.entity.polygon.material = alphaColor;
+        handle.entity.polygon.outline = true;
+        handle.entity.polygon.outlineColor = color;
+      }
+      if (handle.entity.ellipse) {
+        handle.entity.ellipse.material = this.withAlpha(color, 0.4);
+        handle.entity.ellipse.outline = true;
+        handle.entity.ellipse.outlineColor = color;
+      }
+      if (handle.entity.point) {
+        handle.entity.point.color = color;
+      }
+    });
+  }
+
+  private updateGeometry(): void {
+    if (!this.frame) return;
+    const Cesium = getCesium();
+    const scale = computeScale(this.options, this.frame);
+    const pivot = Vector3.fromArray(this.frame.pivot);
+
+    this.handles.forEach((handle) => {
+      switch (handle.type) {
+        case 'translate-axis': {
+          const axisVec = axisVector(this.frame!, handle.axis!);
+          const end = pivot.add(axisVec.multiplyByScalar(scale));
+          handle.entity.polyline = {
+            positions: [toCartesian(pivot.toArray()), toCartesian(end.toArray())],
+            width: 4,
+            material: this.resolveColor(handle.color, handle.axis)
+          };
+          handle.entity.polyline.clampToGround = false;
+          handle.entity.polyline.depthFailMaterial = this.resolveColor(handle.color, handle.axis);
+          break;
+        }
+        case 'translate-plane': {
+          const axisU = axisVector(this.frame!, handle.planeAxes![0]);
+          const axisV = axisVector(this.frame!, handle.planeAxes![1]);
+          const corners = [
+            pivot,
+            pivot.add(axisU.multiplyByScalar(scale * 0.6)),
+            pivot.add(axisU.multiplyByScalar(scale * 0.6)).add(axisV.multiplyByScalar(scale * 0.6)),
+            pivot.add(axisV.multiplyByScalar(scale * 0.6))
+          ];
+          const color = this.resolveColor(handle.color, handle.axis);
+          handle.entity.polygon = {
+            hierarchy: new Cesium.PolygonHierarchy(corners.map((c) => toCartesian(c.toArray()))),
+            material: this.withAlpha(color, 0.2),
+            perPositionHeight: true,
+            outline: true,
+            outlineColor: color
+          };
+          break;
+        }
+        case 'rotate-axis': {
+          const axisVec = axisVector(this.frame!, handle.axis!);
+          const points = generateCirclePoints(pivot, axisVec, scale * 0.85, 64);
+          handle.entity.polyline = {
+            positions: points,
+            width: 2,
+            material: this.resolveColor(handle.color, handle.axis)
+          };
+          break;
+        }
+        case 'rotate-view': {
+          const axisVec = axisVector(this.frame!, 'z');
+          const points = generateCirclePoints(pivot, axisVec, scale * 1.1, 96);
+          handle.entity.polyline = {
+            positions: points,
+            width: 2,
+            material: this.resolveColor('white')
+          };
+          break;
+        }
+        case 'scale-axis': {
+          const axisVec = axisVector(this.frame!, handle.axis!);
+          const end = pivot.add(axisVec.multiplyByScalar(scale));
+          handle.entity.polyline = {
+            positions: [toCartesian(pivot.toArray()), toCartesian(end.toArray())],
+            width: 3,
+            material: this.resolveColor(handle.color, handle.axis)
+          };
+          const boxPosition = pivot.add(axisVec.multiplyByScalar(scale * 1.05));
+          handle.entity.point = {
+            pixelSize: 12,
+            disableDepthTestDistance: Number.POSITIVE_INFINITY,
+            color: this.resolveColor(handle.color, handle.axis)
+          };
+          handle.entity.position = toCartesian(boxPosition.toArray());
+          break;
+        }
+        case 'scale-uniform': {
+          handle.entity.point = {
+            pixelSize: 14,
+            color: this.resolveColor('white'),
+            disableDepthTestDistance: Number.POSITIVE_INFINITY
+          };
+          handle.entity.position = toCartesian(pivot.toArray());
+          break;
+        }
+      }
+    });
+
+    this.applyVisualState();
+    this.updateVisibility();
+  }
+
+  destroy(): void {
+    const Cesium = getCesium();
+    const dataSource = this.viewer.dataSources.getByName('gizmo')[0];
+    if (dataSource) {
+      this.viewer.dataSources.remove(dataSource);
+    }
+  }
+
+  getHandleDefinitions(): HandleDefinition[] {
+    return this.handles;
+  }
+
+  private resolveColor(color: string, axis?: Axis): any {
+    const Cesium = getCesium();
+    if (axis === 'x') return Cesium.Color.RED;
+    if (axis === 'y') return Cesium.Color.LIME;
+    if (axis === 'z') return Cesium.Color.CYAN;
+    if (color === 'white') return Cesium.Color.WHITE;
+    if (color === 'xy') return Cesium.Color.fromBytes(255, 255, 255, 180);
+    if (color === 'yz') return Cesium.Color.fromBytes(255, 255, 255, 180);
+    if (color === 'xz') return Cesium.Color.fromBytes(255, 255, 255, 180);
+    return Cesium.Color.WHITE;
+  }
+
+  private updateVisibility(): void {
+    this.handles.forEach((handle) => {
+      handle.entity.show = this.show && this.modeVisibility[handle.mode];
+    });
+  }
+
+  private withAlpha(color: any, alpha: number): any {
+    if (color.withAlpha) {
+      return color.withAlpha(alpha);
+    }
+    const Cesium = getCesium();
+    return new Cesium.Color(color.red, color.green, color.blue, alpha);
+  }
+
+  private getHoverColor(baseColor: any): any {
+    const Cesium = getCesium();
+    const alpha = typeof baseColor.alpha === 'number' ? baseColor.alpha : 1;
+    return Cesium.Color.YELLOW.withAlpha ? Cesium.Color.YELLOW.withAlpha(alpha) : Cesium.Color.YELLOW;
+  }
+
+  private getActiveColor(baseColor: any): any {
+    const Cesium = getCesium();
+    const alpha = typeof baseColor.alpha === 'number' ? baseColor.alpha : 1;
+    return Cesium.Color.ORANGE.withAlpha ? Cesium.Color.ORANGE.withAlpha(alpha) : Cesium.Color.ORANGE;
+  }
+}

--- a/src/core/HudOverlay.ts
+++ b/src/core/HudOverlay.ts
@@ -1,0 +1,57 @@
+import { TransformDelta } from './types.js';
+
+interface HudOptions {
+  container?: HTMLElement;
+}
+
+export class HudOverlay {
+  private element: HTMLElement;
+
+  constructor(options: HudOptions = {}) {
+    if (options.container) {
+      this.element = options.container;
+    } else {
+      this.element = document.createElement('div');
+      this.element.className = 'manipulator-hud';
+      Object.assign(this.element.style, {
+        position: 'absolute',
+        bottom: '24px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        padding: '6px 12px',
+        background: 'rgba(0,0,0,0.7)',
+        color: '#fff',
+        fontFamily: 'sans-serif',
+        fontSize: '12px',
+        borderRadius: '4px',
+        pointerEvents: 'none',
+        display: 'none'
+      });
+      document.body.appendChild(this.element);
+    }
+  }
+
+  update(delta: TransformDelta, mode: string): void {
+    const [tx, ty, tz] = delta.translation;
+    const [qw, qx, qy, qz] = delta.rotation;
+    const [sx, sy, sz] = delta.scale;
+    const angle = (2 * Math.acos(Math.min(1, Math.max(-1, qw)))) * (180 / Math.PI);
+    this.element.innerHTML = `
+      <div><strong>${mode.toUpperCase()}</strong></div>
+      <div>ΔT: ${tx.toFixed(3)}, ${ty.toFixed(3)}, ${tz.toFixed(3)}</div>
+      <div>ΔR: ${angle.toFixed(2)}° axis=(${qx.toFixed(3)}, ${qy.toFixed(3)}, ${qz.toFixed(3)})</div>
+      <div>ΔS: ${sx.toFixed(3)}, ${sy.toFixed(3)}, ${sz.toFixed(3)}</div>
+    `;
+    this.element.style.display = 'block';
+  }
+
+  hide(): void {
+    this.element.style.display = 'none';
+  }
+
+  destroy(): void {
+    if (this.element.parentElement) {
+      this.element.parentElement.removeChild(this.element);
+    }
+  }
+}

--- a/src/core/ManipulatorController.ts
+++ b/src/core/ManipulatorController.ts
@@ -1,0 +1,186 @@
+import { GizmoPrimitive } from './GizmoPrimitive.js';
+import { GizmoPicker } from './GizmoPicker.js';
+import { TransformSolver } from './TransformSolver.js';
+import { HandleHit, TransformDelta, FrameState, TransformSession } from './types.js';
+import { HudOverlay } from './HudOverlay.js';
+import { Vector3 } from '../utils/math/Vector3.js';
+import { Snapper } from './Snapper.js';
+
+interface DragContext {
+  session: TransformSession;
+  frame: FrameState;
+}
+
+export interface ManipulatorControllerOptions {
+  viewer: any;
+  gizmo: GizmoPrimitive;
+  picker: GizmoPicker;
+  solver: TransformSolver;
+  hud: HudOverlay;
+  snapper: Snapper;
+  createDragContext(handle: HandleHit): DragContext | undefined;
+  onDragDelta(delta: TransformDelta): void;
+  onDragEnd(delta: TransformDelta, cancelled: boolean): void;
+}
+
+function zeroDelta(): TransformDelta {
+  return {
+    translation: [0, 0, 0],
+    rotation: [1, 0, 0, 0],
+    scale: [1, 1, 1]
+  };
+}
+
+function getCesium(): any {
+  const Cesium = (globalThis as any).Cesium;
+  if (!Cesium) {
+    throw new Error('Cesium global is required for ManipulatorController');
+  }
+  return Cesium;
+}
+
+export class ManipulatorController {
+  private viewer: any;
+  private gizmo: GizmoPrimitive;
+  private picker: GizmoPicker;
+  private solver: TransformSolver;
+  private hud: HudOverlay;
+  private snapper: Snapper;
+  private createDragContext: (handle: HandleHit) => DragContext | undefined;
+  private onDragDelta: (delta: TransformDelta) => void;
+  private onDragEnd: (delta: TransformDelta, cancelled: boolean) => void;
+  private handler: any;
+  private state: 'idle' | 'hover' | 'dragging' = 'idle';
+  private activeHandle?: HandleHit;
+  private dragContext?: DragContext;
+  private currentDelta: TransformDelta = zeroDelta();
+  private fineSnap = false;
+  private cancelRequested = false;
+
+  constructor(options: ManipulatorControllerOptions) {
+    this.viewer = options.viewer;
+    this.gizmo = options.gizmo;
+    this.picker = options.picker;
+    this.solver = options.solver;
+    this.hud = options.hud;
+    this.snapper = options.snapper;
+    this.createDragContext = options.createDragContext;
+    this.onDragDelta = options.onDragDelta;
+    this.onDragEnd = options.onDragEnd;
+    this.handler = new (getCesium().ScreenSpaceEventHandler)(this.viewer.scene.canvas);
+    this.bindEvents();
+    this.bindKeyboard();
+  }
+
+  private bindEvents(): void {
+    const Cesium = getCesium();
+    this.handler.setInputAction((movement: any) => this.onMouseMove(movement.endPosition), Cesium.ScreenSpaceEventType.MOUSE_MOVE);
+    this.handler.setInputAction((click: any) => this.onLeftDown(click.position), Cesium.ScreenSpaceEventType.LEFT_DOWN);
+    this.handler.setInputAction((click: any) => this.onLeftUp(click.position), Cesium.ScreenSpaceEventType.LEFT_UP);
+    this.handler.setInputAction(() => this.cancelDrag(), Cesium.ScreenSpaceEventType.RIGHT_DOWN);
+    window.addEventListener('mouseup', () => {
+      if (this.state === 'dragging') {
+        this.onLeftUp(undefined);
+      }
+    });
+  }
+
+  private bindKeyboard(): void {
+    window.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Shift') {
+        this.fineSnap = true;
+      }
+      if (ev.key === 'Escape') {
+        this.cancelDrag();
+      }
+    });
+    window.addEventListener('keyup', (ev) => {
+      if (ev.key === 'Shift') {
+        this.fineSnap = false;
+      }
+    });
+  }
+
+  private onMouseMove(position: any): void {
+    if (!position) return;
+    if (this.state === 'dragging' && this.dragContext) {
+      const ray = this.getPickRay(position);
+      if (!ray) return;
+      const delta = this.solver.update({ currentRay: ray, useFineSnap: this.fineSnap });
+      this.currentDelta = delta;
+      this.hud.update(delta, this.dragContext.session.mode);
+      this.onDragDelta(delta);
+      return;
+    }
+
+    const handle = this.picker.pick(position);
+    if (handle && (!this.activeHandle || handle.id !== this.activeHandle.id)) {
+      this.activeHandle = handle;
+      this.gizmo.setHighlight(handle.id, false);
+      this.state = 'hover';
+    } else if (!handle && this.state !== 'dragging') {
+      this.activeHandle = undefined;
+      this.gizmo.setHighlight(undefined, false);
+      this.state = 'idle';
+    }
+  }
+
+  private onLeftDown(position: any): void {
+    if (!position) return;
+    if (!this.activeHandle) {
+      const handle = this.picker.pick(position);
+      if (!handle) return;
+      this.activeHandle = handle;
+    }
+    if (!this.activeHandle) return;
+    const context = this.createDragContext(this.activeHandle);
+    if (!context) return;
+    const ray = this.getPickRay(position);
+    if (!ray) return;
+    this.dragContext = context;
+    this.state = 'dragging';
+    this.gizmo.setHighlight(this.activeHandle.id, true);
+    this.solver.begin({
+      session: context.session,
+      frame: context.frame,
+      startRay: ray,
+      snapper: this.snapper
+    });
+    this.currentDelta = zeroDelta();
+    this.hud.update(this.currentDelta, context.session.mode);
+  }
+
+  private onLeftUp(position: any | undefined): void {
+    if (this.state !== 'dragging') return;
+    this.state = 'idle';
+    this.gizmo.setHighlight(undefined, false);
+    this.hud.hide();
+    this.solver.end();
+    this.onDragEnd(this.currentDelta, this.cancelRequested);
+    this.cancelRequested = false;
+    this.currentDelta = zeroDelta();
+    this.dragContext = undefined;
+  }
+
+  private cancelDrag(): void {
+    if (this.state === 'dragging') {
+      this.cancelRequested = true;
+      this.onLeftUp(undefined);
+    }
+  }
+
+  private getPickRay(position: any): { origin: Vector3; direction: Vector3 } | undefined {
+    const Cesium = getCesium();
+    const ray = this.viewer.camera.getPickRay(position);
+    if (!ray) return undefined;
+    return {
+      origin: new Vector3(ray.origin.x, ray.origin.y, ray.origin.z),
+      direction: new Vector3(ray.direction.x, ray.direction.y, ray.direction.z).normalize()
+    };
+  }
+
+  destroy(): void {
+    this.handler.destroy();
+    this.hud.hide();
+  }
+}

--- a/src/core/PivotResolver.ts
+++ b/src/core/PivotResolver.ts
@@ -1,0 +1,96 @@
+import { Pivot, PivotResult, TargetLike } from './types.js';
+import { Matrix4 } from '../utils/math/Matrix4.js';
+import { Quaternion } from '../utils/math/Quaternion.js';
+import { Vector3 } from '../utils/math/Vector3.js';
+
+function extractPosition(target: TargetLike): Vector3 {
+  if (target.matrix) {
+    return Matrix4.fromArray(target.matrix).getTranslation();
+  }
+  if (target.position) {
+    return Vector3.fromArray(target.position);
+  }
+  return Vector3.zero();
+}
+
+function buildMatrix(target: TargetLike): Matrix4 {
+  if (target.matrix) {
+    return Matrix4.fromArray(target.matrix);
+  }
+  const position = target.position
+    ? Vector3.fromArray(target.position)
+    : Vector3.zero();
+  const rotation = target.rotation
+    ? new Quaternion(target.rotation[0], target.rotation[1], target.rotation[2], target.rotation[3])
+    : Quaternion.identity();
+  const scale = target.scale
+    ? Vector3.fromArray(target.scale)
+    : new Vector3(1, 1, 1);
+  return Matrix4.fromTranslationRotationScale(position, rotation, scale);
+}
+
+export class PivotResolver {
+  constructor(private cursor?: { position: Vector3 }) {}
+
+  resolve(pivot: Pivot, targets: TargetLike[]): PivotResult {
+    if (targets.length === 0) {
+      return { pivot: [0, 0, 0] };
+    }
+
+    switch (pivot) {
+      case 'origin':
+        return { pivot: extractPosition(targets[0]).toArray() };
+      case 'median':
+        return this.resolveMedian(targets);
+      case 'cursor':
+        return this.resolveCursor();
+      case 'individual':
+        return this.resolveIndividual(targets);
+      default:
+        return { pivot: extractPosition(targets[0]).toArray() };
+    }
+  }
+
+  private resolveMedian(targets: TargetLike[]): PivotResult {
+    const sum = targets.reduce((acc, target) => acc.add(extractPosition(target)), Vector3.zero());
+    const center = sum.divideByScalar(targets.length);
+    return { pivot: center.toArray() };
+  }
+
+  private resolveCursor(): PivotResult {
+    if (this.cursor) {
+      return { pivot: this.cursor.position.toArray() };
+    }
+    return { pivot: [0, 0, 0] };
+  }
+
+  private resolveIndividual(targets: TargetLike[]): PivotResult {
+    const entries = targets.map((target) => ({
+      target,
+      pivot: extractPosition(target).toArray() as [number, number, number]
+    }));
+    return {
+      pivot: entries[0].pivot,
+      perTarget: entries
+    };
+  }
+
+  static applyDelta(target: TargetLike, delta: { translation: Vector3; rotation: Quaternion; scale: Vector3 }): TargetLike {
+    const matrix = buildMatrix(target);
+    const translation = matrix.getTranslation().add(delta.translation);
+    const rotation = matrix.getRotation().multiply(delta.rotation).normalize();
+    const scale = new Vector3(
+      matrix.getScale().x * delta.scale.x,
+      matrix.getScale().y * delta.scale.y,
+      matrix.getScale().z * delta.scale.z
+    );
+
+    return {
+      ...target,
+      position: translation.toArray(),
+      rotation: [rotation.w, rotation.x, rotation.y, rotation.z],
+      scale: scale.toArray(),
+      matrix: Matrix4.fromTranslationRotationScale(translation, rotation, scale).elements
+    };
+  }
+}

--- a/src/core/Snapper.ts
+++ b/src/core/Snapper.ts
@@ -1,0 +1,38 @@
+import { SnapConfig } from './types';
+
+export interface SnapContext {
+  config: SnapConfig;
+  useFine: boolean;
+}
+
+export class Snapper {
+  constructor(private config: SnapConfig = {}) {}
+
+  updateConfig(config: SnapConfig): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  snapTranslation(value: number, useFine = false): number {
+    const step = this.config.translateStep || 0;
+    if (step <= 0) return value;
+    const factor = useFine ? this.config.fineTranslateFactor || 0.1 : 1;
+    const effective = step * factor;
+    return Math.round(value / effective) * effective;
+  }
+
+  snapRotation(value: number, useFine = false): number {
+    const step = this.config.rotateStep || 0;
+    if (step <= 0) return value;
+    const factor = useFine ? this.config.fineRotateFactor || 0.1 : 1;
+    const effective = step * factor;
+    return Math.round(value / effective) * effective;
+  }
+
+  snapScale(value: number, useFine = false): number {
+    const step = this.config.scaleStep || 0;
+    if (step <= 0) return value;
+    const factor = useFine ? this.config.fineScaleFactor || 0.1 : 1;
+    const effective = step * factor;
+    return Math.round(value / effective) * effective;
+  }
+}

--- a/src/core/TransformSolver.ts
+++ b/src/core/TransformSolver.ts
@@ -1,0 +1,365 @@
+import { FrameState, TransformSession, TransformDelta, Axis } from './types.js';
+import { Vector3 } from '../utils/math/Vector3.js';
+import { Quaternion } from '../utils/math/Quaternion.js';
+import { closestPointsBetweenRays, intersectRayPlane, Ray as MathRay } from '../utils/math/Ray.js';
+import { Snapper } from './Snapper.js';
+
+export interface BeginTransformOptions {
+  session: TransformSession;
+  frame: FrameState;
+  startRay: MathRay;
+  snapper: Snapper;
+}
+
+export interface UpdateTransformOptions {
+  currentRay: MathRay;
+  useFineSnap?: boolean;
+}
+
+interface BaseInternalSession {
+  session: TransformSession;
+  frame: FrameState;
+  snapper: Snapper;
+  startDelta: TransformDelta;
+}
+
+interface AxisTranslationSession extends BaseInternalSession {
+  type: 'axis-translate';
+  axis: Axis;
+  pivot: Vector3;
+  axisVector: Vector3;
+  startParameter: number;
+}
+
+interface PlaneTranslationSession extends BaseInternalSession {
+  type: 'plane-translate';
+  axisU: Vector3;
+  axisV: Vector3;
+  pivot: Vector3;
+  startPoint: Vector3;
+}
+
+interface RotationSession extends BaseInternalSession {
+  type: 'axis-rotate' | 'view-rotate';
+  axis: Vector3;
+  pivot: Vector3;
+  startVector: Vector3;
+}
+
+interface ScaleSession extends BaseInternalSession {
+  type: 'axis-scale' | 'uniform-scale';
+  axis?: Vector3;
+  pivot: Vector3;
+  startParameter?: number;
+  planeNormal?: Vector3;
+}
+
+type InternalSession =
+  | AxisTranslationSession
+  | PlaneTranslationSession
+  | RotationSession
+  | ScaleSession;
+
+function axisToVector(frame: FrameState, axis: Axis): Vector3 {
+  const value = frame.axes[axis];
+  return Vector3.fromArray(value).normalize();
+}
+
+function zeroDelta(): TransformDelta {
+  return {
+    translation: [0, 0, 0],
+    rotation: [1, 0, 0, 0],
+    scale: [1, 1, 1]
+  };
+}
+
+export class TransformSolver {
+  private current?: InternalSession;
+
+  begin(options: BeginTransformOptions): void {
+    const { session, frame, startRay, snapper } = options;
+    const pivot = Vector3.fromArray(frame.pivot);
+
+    if (session.mode === 'translate' && session.axis) {
+      const axisVec = axisToVector(frame, session.axis);
+      const axisRay: MathRay = { origin: pivot, direction: axisVec };
+      const startInfo = closestPointsBetweenRays(startRay, axisRay);
+      this.current = {
+        type: 'axis-translate',
+        session,
+        frame,
+        snapper,
+        pivot,
+        axis: session.axis,
+        axisVector: axisVec,
+        startParameter: startInfo.parameterB,
+        startDelta: zeroDelta()
+      };
+      return;
+    }
+
+    if (session.mode === 'translate' && session.planeAxes) {
+      const [axU, axV] = session.planeAxes;
+      const axisU = axisToVector(frame, axU);
+      const axisV = axisToVector(frame, axV);
+      const planeNormal = axisU.cross(axisV).normalize();
+      const startPoint = intersectRayPlane(startRay, pivot, planeNormal) ?? pivot;
+      this.current = {
+        type: 'plane-translate',
+        session,
+        frame,
+        snapper,
+        axisU,
+        axisV,
+        pivot,
+        startPoint,
+        startDelta: zeroDelta()
+      };
+      return;
+    }
+
+    if (session.mode === 'rotate' && session.axis) {
+      const axisVec = axisToVector(frame, session.axis);
+      const planeNormal = axisVec;
+      const startPoint = intersectRayPlane(startRay, pivot, planeNormal) ?? pivot.add(axisVec);
+      const startVector = startPoint.subtract(pivot).normalize();
+      this.current = {
+        type: 'axis-rotate',
+        session,
+        frame,
+        snapper,
+        axis: axisVec,
+        pivot,
+        startVector,
+        startDelta: zeroDelta()
+      };
+      return;
+    }
+
+    if (session.mode === 'rotate' && session.viewNormal) {
+      const normal = Vector3.fromArray(session.viewNormal).normalize();
+      const startPoint = intersectRayPlane(startRay, pivot, normal) ?? pivot.add(normal);
+      const startVector = startPoint.subtract(pivot).normalize();
+      this.current = {
+        type: 'view-rotate',
+        session,
+        frame,
+        snapper,
+        axis: normal,
+        pivot,
+        startVector,
+        startDelta: zeroDelta()
+      };
+      return;
+    }
+
+    if (session.mode === 'scale' && session.axis) {
+      const axisVec = axisToVector(frame, session.axis);
+      const axisRay: MathRay = { origin: pivot, direction: axisVec };
+      const startInfo = closestPointsBetweenRays(startRay, axisRay);
+      this.current = {
+        type: 'axis-scale',
+        session,
+        frame,
+        snapper,
+        axis: axisVec,
+        pivot,
+        startParameter: startInfo.parameterB,
+        startDelta: zeroDelta()
+      };
+      return;
+    }
+
+    if (session.mode === 'scale' && session.uniformScale) {
+      const axisX = axisToVector(frame, 'x');
+      const axisY = axisToVector(frame, 'y');
+      const normal = axisX.cross(axisY).normalize();
+      const startPoint = intersectRayPlane(startRay, pivot, normal) ?? pivot.add(axisX);
+      const startVector = startPoint.subtract(pivot);
+      const startParameter = Math.max(1e-6, startVector.length());
+      this.current = {
+        type: 'uniform-scale',
+        session,
+        frame,
+        snapper,
+        pivot,
+        startParameter,
+        planeNormal: normal,
+        startDelta: zeroDelta()
+      };
+      return;
+    }
+
+    throw new Error('Unsupported transform session');
+  }
+
+  update(options: UpdateTransformOptions): TransformDelta {
+    if (!this.current) {
+      return zeroDelta();
+    }
+    const { currentRay, useFineSnap } = options;
+
+    switch (this.current.type) {
+      case 'axis-translate':
+        return this.updateAxisTranslate(this.current, currentRay, !!useFineSnap);
+      case 'plane-translate':
+        return this.updatePlaneTranslate(this.current, currentRay, !!useFineSnap);
+      case 'axis-rotate':
+        return this.updateAxisRotate(this.current, currentRay, !!useFineSnap);
+      case 'view-rotate':
+        return this.updateViewRotate(this.current, currentRay, !!useFineSnap);
+      case 'axis-scale':
+        return this.updateAxisScale(this.current, currentRay, !!useFineSnap);
+      case 'uniform-scale':
+        return this.updateUniformScale(this.current, currentRay, !!useFineSnap);
+      default:
+        return zeroDelta();
+    }
+  }
+
+  end(): void {
+    this.current = undefined;
+  }
+
+  private updateAxisTranslate(
+    session: AxisTranslationSession,
+    currentRay: MathRay,
+    useFine: boolean
+  ): TransformDelta {
+    const axisRay: MathRay = { origin: session.pivot, direction: session.axisVector };
+    const info = closestPointsBetweenRays(currentRay, axisRay);
+    const deltaParam = info.parameterB - session.startParameter;
+    const snapped = session.snapper.snapTranslation(deltaParam, useFine);
+    const deltaVec = session.axisVector.multiplyByScalar(snapped);
+    return {
+      translation: deltaVec.toArray(),
+      rotation: [1, 0, 0, 0],
+      scale: [1, 1, 1]
+    };
+  }
+
+  private updatePlaneTranslate(
+    session: PlaneTranslationSession,
+    currentRay: MathRay,
+    useFine: boolean
+  ): TransformDelta {
+    const planeNormal = session.axisU.cross(session.axisV).normalize();
+    const hit = intersectRayPlane(currentRay, session.pivot, planeNormal) ?? session.startPoint;
+    const delta = hit.subtract(session.startPoint);
+    const uScalar = delta.dot(session.axisU);
+    const vScalar = delta.dot(session.axisV);
+    const snappedU = session.snapper.snapTranslation(uScalar, useFine);
+    const snappedV = session.snapper.snapTranslation(vScalar, useFine);
+    const deltaVec = session.axisU.multiplyByScalar(snappedU).add(session.axisV.multiplyByScalar(snappedV));
+    return {
+      translation: deltaVec.toArray(),
+      rotation: [1, 0, 0, 0],
+      scale: [1, 1, 1]
+    };
+  }
+
+  private updateAxisRotate(
+    session: RotationSession,
+    currentRay: MathRay,
+    useFine: boolean
+  ): TransformDelta {
+    const planeNormal = session.axis;
+    const hit = intersectRayPlane(currentRay, session.pivot, planeNormal) ?? session.pivot.add(session.startVector);
+    const currentVector = hit.subtract(session.pivot).normalize();
+    const angle = this.computeSignedAngle(session.startVector, currentVector, session.axis);
+    const snapped = session.snapper.snapRotation(angle, useFine);
+    const quaternion = Quaternion.fromAxisAngle(session.axis, snapped).normalize();
+    return {
+      translation: [0, 0, 0],
+      rotation: [quaternion.w, quaternion.x, quaternion.y, quaternion.z],
+      scale: [1, 1, 1]
+    };
+  }
+
+  private updateViewRotate(
+    session: RotationSession,
+    currentRay: MathRay,
+    useFine: boolean
+  ): TransformDelta {
+    const hit = intersectRayPlane(currentRay, session.pivot, session.axis) ?? session.pivot.add(session.startVector);
+    const currentVector = hit.subtract(session.pivot).normalize();
+    const angle = this.computeSignedAngle(session.startVector, currentVector, session.axis);
+    const snapped = session.snapper.snapRotation(angle, useFine);
+    const quaternion = Quaternion.fromAxisAngle(session.axis, snapped).normalize();
+    return {
+      translation: [0, 0, 0],
+      rotation: [quaternion.w, quaternion.x, quaternion.y, quaternion.z],
+      scale: [1, 1, 1]
+    };
+  }
+
+  private updateAxisScale(
+    session: ScaleSession,
+    currentRay: MathRay,
+    useFine: boolean
+  ): TransformDelta {
+    if (!session.axis || session.startParameter === undefined) {
+      return zeroDelta();
+    }
+    const axisRay: MathRay = { origin: session.pivot, direction: session.axis };
+    const info = closestPointsBetweenRays(currentRay, axisRay);
+    const deltaParam = info.parameterB - session.startParameter;
+    const snapped = session.snapper.snapScale(deltaParam, useFine);
+    const factor = Math.max(1e-4, 1 + snapped);
+    const scale: [number, number, number] = [1, 1, 1];
+    const axisIndex = this.axisIndexFromVector(session.axis, session.frame);
+    scale[axisIndex] = factor;
+    return {
+      translation: [0, 0, 0],
+      rotation: [1, 0, 0, 0],
+      scale
+    };
+  }
+
+  private updateUniformScale(
+    session: ScaleSession,
+    currentRay: MathRay,
+    useFine: boolean
+  ): TransformDelta {
+    if (session.startParameter === undefined || !session.planeNormal) {
+      return zeroDelta();
+    }
+    const planeNormal = session.planeNormal;
+    const hit = intersectRayPlane(currentRay, session.pivot, planeNormal) ?? session.pivot;
+    const distance = hit.subtract(session.pivot).length();
+    const delta = distance - session.startParameter;
+    const snapped = session.snapper.snapScale(delta, useFine);
+    const factor = Math.max(1e-4, 1 + snapped);
+    return {
+      translation: [0, 0, 0],
+      rotation: [1, 0, 0, 0],
+      scale: [factor, factor, factor]
+    };
+  }
+
+  private computeSignedAngle(a: Vector3, b: Vector3, axis: Vector3): number {
+    const cross = a.cross(b);
+    const dot = a.dot(b);
+    const angle = Math.atan2(cross.length(), dot);
+    const sign = Math.sign(cross.dot(axis));
+    return angle * (sign === 0 ? 1 : sign);
+  }
+
+  private axisIndexFromVector(axis: Vector3, frame: FrameState): 0 | 1 | 2 {
+    const axes: [Vector3, Vector3, Vector3] = [
+      Vector3.fromArray(frame.axes.x),
+      Vector3.fromArray(frame.axes.y),
+      Vector3.fromArray(frame.axes.z)
+    ];
+    let bestIndex: 0 | 1 | 2 = 0;
+    let bestDot = -Infinity;
+    axes.forEach((candidate, index) => {
+      const dot = Math.abs(candidate.normalize().dot(axis.normalize()));
+      if (dot > bestDot) {
+        bestDot = dot;
+        bestIndex = index as 0 | 1 | 2;
+      }
+    });
+    return bestIndex;
+  }
+}

--- a/src/core/UniversalManipulator.ts
+++ b/src/core/UniversalManipulator.ts
@@ -1,0 +1,352 @@
+import {
+  ManipulatorOptions,
+  Mode,
+  Orientation,
+  Pivot,
+  TargetLike,
+  TransformDelta,
+  HandleHit,
+  FrameState,
+  TransformSession,
+  CursorState
+} from './types.js';
+import { GizmoPrimitive } from './GizmoPrimitive.js';
+import { GizmoPicker } from './GizmoPicker.js';
+import { ManipulatorController } from './ManipulatorController.js';
+import { TransformSolver } from './TransformSolver.js';
+import { Snapper } from './Snapper.js';
+import { PivotResolver } from './PivotResolver.js';
+import { FrameBuilder } from './FrameBuilder.js';
+import { HudOverlay } from './HudOverlay.js';
+import { CommandStack } from './CommandStack.js';
+import { Vector3 } from '../utils/math/Vector3.js';
+import { Quaternion } from '../utils/math/Quaternion.js';
+import { Matrix4 } from '../utils/math/Matrix4.js';
+
+interface TargetAdapter {
+  source: TargetLike;
+  getMatrix(): Matrix4;
+  applyMatrix(matrix: Matrix4): void;
+}
+
+interface ActiveDragState {
+  frame: FrameState;
+  startMatrices: Matrix4[];
+  pivotPerTarget: Array<[number, number, number]>;
+}
+
+function zeroDelta(): TransformDelta {
+  return {
+    translation: [0, 0, 0],
+    rotation: [1, 0, 0, 0],
+    scale: [1, 1, 1]
+  };
+}
+
+export class UniversalManipulator {
+  private viewer: any;
+  private gizmo: GizmoPrimitive;
+  private picker: GizmoPicker;
+  private snapper: Snapper;
+  private solver: TransformSolver;
+  private hud: HudOverlay;
+  private controller: ManipulatorController;
+  private commandStack = new CommandStack();
+  private adapters: TargetAdapter[] = [];
+  private orientation: Orientation = 'global';
+  private pivot: Pivot = 'origin';
+  private enableTranslate = true;
+  private enableRotate = true;
+  private enableScale = true;
+  private screenPixelRadius = 80;
+  private minScale = 1;
+  private maxScale = 1000;
+  private show = true;
+  private activeDrag?: ActiveDragState;
+  private lastDelta: TransformDelta = zeroDelta();
+  private cursor?: CursorState;
+
+  constructor(viewer: any, options: ManipulatorOptions = {}) {
+    this.viewer = viewer;
+    this.orientation = options.orientation ?? this.orientation;
+    this.pivot = options.pivot ?? this.pivot;
+    this.enableTranslate = options.enableTranslate ?? true;
+    this.enableRotate = options.enableRotate ?? true;
+    this.enableScale = options.enableScale ?? true;
+    this.screenPixelRadius = options.screenPixelRadius ?? this.screenPixelRadius;
+    this.minScale = options.minScale ?? this.minScale;
+    this.maxScale = options.maxScale ?? this.maxScale;
+    this.snapper = new Snapper(options.snap ?? {});
+    this.gizmo = new GizmoPrimitive({
+      viewer,
+      screenPixelRadius: this.screenPixelRadius,
+      minScale: this.minScale,
+      maxScale: this.maxScale
+    });
+    this.gizmo.setModeVisibility({
+      translate: this.enableTranslate,
+      rotate: this.enableRotate,
+      scale: this.enableScale
+    });
+    this.picker = new GizmoPicker({ viewer, gizmo: this.gizmo });
+    this.solver = new TransformSolver();
+    this.hud = new HudOverlay();
+    this.controller = new ManipulatorController({
+      viewer,
+      gizmo: this.gizmo,
+      picker: this.picker,
+      solver: this.solver,
+      hud: this.hud,
+      snapper: this.snapper,
+      createDragContext: (handle) => this.createDragContext(handle),
+      onDragDelta: (delta) => this.applyDelta(delta, false),
+      onDragEnd: (delta, cancelled) => this.finishDrag(delta, cancelled)
+    });
+    if (options.target) {
+      this.setTarget(options.target);
+    }
+  }
+
+  set showManipulator(value: boolean) {
+    this.show = value;
+    this.gizmo.setShow(value);
+  }
+
+  setTarget(target: TargetLike | TargetLike[]): void {
+    const array = Array.isArray(target) ? target : [target];
+    this.adapters = array.map((item) => this.createAdapter(item));
+    this.updateFrame();
+  }
+
+  setCursor(cursor: CursorState): void {
+    this.cursor = cursor;
+    this.updateFrame();
+  }
+
+  setOrientation(orientation: Orientation): void {
+    this.orientation = orientation;
+    this.updateFrame();
+  }
+
+  setPivot(pivot: Pivot): void {
+    this.pivot = pivot;
+    this.updateFrame();
+  }
+
+  enable(options: Partial<Record<Mode, boolean>>): void {
+    if (typeof options.translate === 'boolean') {
+      this.enableTranslate = options.translate;
+    }
+    if (typeof options.rotate === 'boolean') {
+      this.enableRotate = options.rotate;
+    }
+    if (typeof options.scale === 'boolean') {
+      this.enableScale = options.scale;
+    }
+    this.gizmo.setModeVisibility({
+      translate: this.enableTranslate,
+      rotate: this.enableRotate,
+      scale: this.enableScale
+    });
+  }
+
+  setSnap(config: ManipulatorOptions['snap']): void {
+    if (config) {
+      this.snapper.updateConfig(config);
+    }
+  }
+
+  setSize(screenPixelRadius: number, minScale?: number, maxScale?: number): void {
+    this.screenPixelRadius = screenPixelRadius;
+    if (minScale !== undefined) this.minScale = minScale;
+    if (maxScale !== undefined) this.maxScale = maxScale;
+    this.gizmo.updateSize({
+      screenPixelRadius: this.screenPixelRadius,
+      minScale: this.minScale,
+      maxScale: this.maxScale
+    });
+    this.updateFrame();
+  }
+
+  destroy(): void {
+    this.controller.destroy();
+    this.gizmo.destroy();
+    this.hud.destroy();
+  }
+
+  private createAdapter(target: TargetLike): TargetAdapter {
+    const toMatrix = (input: TargetLike): Matrix4 => {
+      if (input.matrix) {
+        return Matrix4.fromArray(input.matrix);
+      }
+      const position = input.position ? Vector3.fromArray(input.position) : Vector3.zero();
+      const rotation = input.rotation
+        ? new Quaternion(input.rotation[0], input.rotation[1], input.rotation[2], input.rotation[3])
+        : Quaternion.identity();
+      const scale = input.scale ? Vector3.fromArray(input.scale) : new Vector3(1, 1, 1);
+      return Matrix4.fromTranslationRotationScale(position, rotation, scale);
+    };
+
+    return {
+      source: target,
+      getMatrix: () => toMatrix(target),
+      applyMatrix: (matrix: Matrix4) => {
+        target.matrix = [...matrix.elements];
+        const translation = matrix.getTranslation();
+        const rotation = matrix.getRotation();
+        const scale = matrix.getScale();
+        target.position = translation.toArray();
+        target.rotation = [rotation.w, rotation.x, rotation.y, rotation.z];
+        target.scale = scale.toArray();
+      }
+    };
+  }
+
+  private updateFrame(): void {
+    if (this.adapters.length === 0) {
+      return;
+    }
+    const frame = this.computeFrame();
+    this.gizmo.setFrame(frame);
+  }
+
+  private computeFrame(): FrameState {
+    const targets = this.adapters.map((adapter) => ({ matrix: adapter.getMatrix().elements }));
+    const pivotResolver = this.createPivotResolver();
+    const pivotResult = pivotResolver.resolve(this.pivot, targets);
+    const cameraInfo = this.getCameraInfo();
+    const frameBuilder = new FrameBuilder({
+      orientation: this.orientation,
+      targets,
+      pivot: pivotResult.pivot,
+      camera: cameraInfo
+    });
+    return frameBuilder.build();
+  }
+
+  private getCameraInfo() {
+    const camera = this.viewer.camera;
+    const direction = camera.directionWC || camera.direction;
+    const up = camera.upWC || camera.up;
+    const right = camera.rightWC || camera.right;
+    const position = camera.positionWC || camera.position;
+    return {
+      position: [position.x, position.y, position.z] as [number, number, number],
+      direction: [direction.x, direction.y, direction.z] as [number, number, number],
+      up: [up.x, up.y, up.z] as [number, number, number],
+      right: [right.x, right.y, right.z] as [number, number, number]
+    };
+  }
+
+  private createDragContext(handle: HandleHit): { session: TransformSession; frame: FrameState } | undefined {
+    if (this.adapters.length === 0) {
+      return undefined;
+    }
+    const frame = this.computeFrame();
+    const session: TransformSession = {
+      mode: handle.mode
+    };
+    if (handle.axis) {
+      session.axis = handle.axis;
+    }
+    if (handle.planeAxes) {
+      session.planeAxes = handle.planeAxes;
+    }
+    if (handle.uniformScale) {
+      session.uniformScale = handle.uniformScale;
+    }
+    if (handle.id === 'rotate-view') {
+      const camera = this.viewer.camera;
+      const dir = camera.directionWC || camera.direction;
+      session.viewNormal = [dir.x, dir.y, dir.z];
+    }
+
+    const pivotResolver = this.createPivotResolver();
+    const targets = this.adapters.map((adapter) => ({ matrix: adapter.getMatrix().elements }));
+    const pivotResult = pivotResolver.resolve(this.pivot, targets);
+    const pivots: Array<[number, number, number]> = pivotResult.perTarget
+      ? pivotResult.perTarget.map((entry) => entry.pivot)
+      : targets.map(() => pivotResult.pivot);
+    this.activeDrag = {
+      frame,
+      startMatrices: this.adapters.map((adapter) => adapter.getMatrix()),
+      pivotPerTarget: pivots
+    };
+    return { session, frame };
+  }
+
+  private applyDelta(delta: TransformDelta, commit: boolean): void {
+    if (!this.activeDrag) {
+      return;
+    }
+    const rotation = new Quaternion(delta.rotation[0], delta.rotation[1], delta.rotation[2], delta.rotation[3]).normalize();
+    const translation = Vector3.fromArray(delta.translation);
+    const scale = Vector3.fromArray(delta.scale);
+
+    this.adapters.forEach((adapter, index) => {
+      const startMatrix = this.activeDrag!.startMatrices[index];
+      const pivotArray = this.activeDrag!.pivotPerTarget[index];
+      const pivot = Vector3.fromArray(pivotArray);
+      const newMatrix = this.composeDelta(startMatrix, translation, rotation, scale, pivot);
+      adapter.applyMatrix(newMatrix);
+      if (!commit) {
+        // reset start matrices for continuous updates to avoid drift
+        this.activeDrag!.startMatrices[index] = startMatrix;
+      }
+    });
+
+    this.lastDelta = delta;
+    this.updateFrame();
+  }
+
+  private composeDelta(
+    startMatrix: Matrix4,
+    translation: Vector3,
+    rotation: Quaternion,
+    scale: Vector3,
+    pivot: Vector3
+  ): Matrix4 {
+    const translationMatrix = Matrix4.fromTranslationRotationScale(translation, Quaternion.identity(), new Vector3(1, 1, 1));
+    const pivotMatrix = Matrix4.fromTranslationRotationScale(pivot, Quaternion.identity(), new Vector3(1, 1, 1));
+    const invPivotMatrix = Matrix4.fromTranslationRotationScale(pivot.multiplyByScalar(-1), Quaternion.identity(), new Vector3(1, 1, 1));
+    const rotationMatrix = Matrix4.fromTranslationRotationScale(Vector3.zero(), rotation, new Vector3(1, 1, 1));
+    const scaleMatrix = Matrix4.fromTranslationRotationScale(Vector3.zero(), Quaternion.identity(), scale);
+    const deltaMatrix = translationMatrix
+      .multiply(pivotMatrix)
+      .multiply(rotationMatrix)
+      .multiply(scaleMatrix)
+      .multiply(invPivotMatrix);
+    return deltaMatrix.multiply(startMatrix);
+  }
+
+  private finishDrag(delta: TransformDelta, cancelled: boolean): void {
+    if (!this.activeDrag) {
+      return;
+    }
+    if (cancelled) {
+      this.restoreStartMatrices();
+    } else {
+      this.applyDelta(delta, true);
+      this.commandStack.push({ targets: this.adapters.map((adapter) => adapter.source), delta });
+    }
+    this.activeDrag = undefined;
+    this.lastDelta = zeroDelta();
+    this.updateFrame();
+  }
+
+  private restoreStartMatrices(): void {
+    if (!this.activeDrag) return;
+    this.adapters.forEach((adapter, index) => {
+      const matrix = this.activeDrag!.startMatrices[index];
+      adapter.applyMatrix(matrix);
+    });
+  }
+
+  private createPivotResolver(): PivotResolver {
+    if (this.cursor) {
+      const position = Vector3.fromArray(this.cursor.position);
+      return new PivotResolver({ position });
+    }
+    return new PivotResolver();
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,107 @@
+export type Axis = 'x' | 'y' | 'z';
+export type Mode = 'translate' | 'rotate' | 'scale';
+export type Orientation = 'global' | 'local' | 'view' | 'enu' | 'normal' | 'gimbal';
+export type Pivot = 'origin' | 'median' | 'cursor' | 'individual';
+
+export interface Ray {
+  origin: [number, number, number];
+  direction: [number, number, number];
+}
+
+export interface TransformDelta {
+  translation: [number, number, number];
+  rotation: [number, number, number, number];
+  scale: [number, number, number];
+}
+
+export interface TargetTransform {
+  matrix: number[]; // 16 elements column-major
+}
+
+export interface TargetLike {
+  id?: string;
+  matrix?: number[];
+  position?: [number, number, number];
+  rotation?: [number, number, number, number];
+  scale?: [number, number, number];
+}
+
+export interface TransformSession {
+  mode: Mode;
+  axis?: Axis;
+  planeAxes?: [Axis, Axis];
+  uniformScale?: boolean;
+  viewNormal?: [number, number, number];
+}
+
+export interface SnapConfig {
+  translateStep?: number;
+  rotateStep?: number;
+  scaleStep?: number;
+  fineTranslateFactor?: number;
+  fineRotateFactor?: number;
+  fineScaleFactor?: number;
+}
+
+export interface FrameState {
+  pivot: [number, number, number];
+  axes: {
+    x: [number, number, number];
+    y: [number, number, number];
+    z: [number, number, number];
+  };
+  matrix: number[];
+}
+
+export interface ManipulatorOptions {
+  target?: TargetLike | TargetLike[];
+  orientation?: Orientation;
+  pivot?: Pivot;
+  enableTranslate?: boolean;
+  enableRotate?: boolean;
+  enableScale?: boolean;
+  snap?: SnapConfig;
+  screenPixelRadius?: number;
+  minScale?: number;
+  maxScale?: number;
+}
+
+export interface HandleHit {
+  id: string;
+  mode: Mode;
+  axis?: Axis;
+  planeAxes?: [Axis, Axis];
+  uniformScale?: boolean;
+  priority: number;
+  screenPosition: { x: number; y: number };
+}
+
+export interface CameraInfo {
+  position: [number, number, number];
+  direction: [number, number, number];
+  up: [number, number, number];
+  right: [number, number, number];
+}
+
+export interface CursorState {
+  position: [number, number, number];
+  normal?: [number, number, number];
+}
+
+export interface PivotResult {
+  pivot: [number, number, number];
+  perTarget?: Array<{ target: TargetLike; pivot: [number, number, number] }>;
+}
+
+export interface TransformCommand {
+  targets: TargetLike[];
+  delta: TransformDelta;
+}
+
+export interface CommandStack {
+  push(command: TransformCommand): void;
+  undo(): void;
+  redo(): void;
+  clear(): void;
+}
+

--- a/src/example/main.ts
+++ b/src/example/main.ts
@@ -1,0 +1,103 @@
+import { UniversalManipulator } from '../core/UniversalManipulator.js';
+import { Orientation, Pivot, TargetLike } from '../core/types.js';
+import { Matrix4 as MathMatrix4 } from '../utils/math/Matrix4.js';
+
+const Cesium = (window as any).Cesium;
+
+function createViewer(): any {
+  const viewer = new Cesium.Viewer('cesiumContainer', {
+    animation: false,
+    timeline: false,
+    infoBox: false,
+    geocoder: false
+  });
+  viewer.scene.globe.depthTestAgainstTerrain = false;
+  viewer.scene.globe.enableLighting = true;
+  return viewer;
+}
+
+function createBoxEntity(viewer: any): any {
+  const position = Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883, 30);
+  const modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(position);
+  const entity = viewer.entities.add({
+    name: 'Draggable box',
+    modelMatrix,
+    box: {
+      dimensions: new Cesium.Cartesian3(10, 10, 10),
+      material: Cesium.Color.WHITE.withAlpha(0.8),
+      outline: true,
+      outlineColor: Cesium.Color.DEEPSKYBLUE
+    }
+  });
+  return entity;
+}
+
+function toTargetLike(matrix: any): TargetLike {
+  const elements = Array.from(matrix as number[]);
+  const mathMatrix = MathMatrix4.fromArray(elements);
+  const translation = mathMatrix.getTranslation();
+  const rotation = mathMatrix.getRotation();
+  const scale = mathMatrix.getScale();
+  return {
+    matrix: elements,
+    position: translation.toArray(),
+    rotation: [rotation.w, rotation.x, rotation.y, rotation.z],
+    scale: scale.toArray()
+  };
+}
+
+function applyMatrixToEntity(entity: any, target: TargetLike): void {
+  if (!target.matrix) return;
+  entity.modelMatrix = Cesium.Matrix4.fromArray(target.matrix);
+}
+
+function buildUi(manipulator: UniversalManipulator): void {
+  const orientationSelect = document.getElementById('orientation') as HTMLSelectElement;
+  const pivotSelect = document.getElementById('pivot') as HTMLSelectElement;
+  const translateToggle = document.getElementById('enable-translate') as HTMLInputElement;
+  const rotateToggle = document.getElementById('enable-rotate') as HTMLInputElement;
+  const scaleToggle = document.getElementById('enable-scale') as HTMLInputElement;
+
+  orientationSelect.addEventListener('change', () => {
+    manipulator.setOrientation(orientationSelect.value as Orientation);
+  });
+
+  pivotSelect.addEventListener('change', () => {
+    manipulator.setPivot(pivotSelect.value as Pivot);
+  });
+
+  const updateModes = () => {
+    manipulator.enable({
+      translate: translateToggle.checked,
+      rotate: rotateToggle.checked,
+      scale: scaleToggle.checked
+    });
+  };
+
+  translateToggle.addEventListener('change', updateModes);
+  rotateToggle.addEventListener('change', updateModes);
+  scaleToggle.addEventListener('change', updateModes);
+}
+
+(async function init() {
+  const viewer = createViewer();
+  const entity = createBoxEntity(viewer);
+  const target = toTargetLike(Cesium.Matrix4.toArray(entity.modelMatrix));
+  const manipulator = new UniversalManipulator(viewer, {
+    target,
+    orientation: 'enu',
+    pivot: 'origin',
+    screenPixelRadius: 90,
+    snap: {
+      translateStep: 1,
+      rotateStep: Cesium.Math.toRadians(5),
+      scaleStep: 0.1
+    }
+  });
+
+  viewer.scene.preRender.addEventListener(() => {
+    applyMatrixToEntity(entity, target);
+  });
+
+  buildUi(manipulator);
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,15 @@
+export * from './core/types.js';
+export { UniversalManipulator } from './core/UniversalManipulator.js';
+export { GizmoPrimitive } from './core/GizmoPrimitive.js';
+export { GizmoPicker } from './core/GizmoPicker.js';
+export { ManipulatorController } from './core/ManipulatorController.js';
+export { TransformSolver } from './core/TransformSolver.js';
+export { Snapper } from './core/Snapper.js';
+export { PivotResolver } from './core/PivotResolver.js';
+export { FrameBuilder } from './core/FrameBuilder.js';
+export { HudOverlay } from './core/HudOverlay.js';
+export { CommandStack } from './core/CommandStack.js';
+export { Vector3, fromArray as vector3FromArray, toArray as vector3ToArray } from './utils/math/Vector3.js';
+export { Quaternion, quaternionFromArray, quaternionToArray } from './utils/math/Quaternion.js';
+export { Matrix4, matrix4FromArray, matrix4ToArray } from './utils/math/Matrix4.js';
+export { Ray as MathRay, closestPointsBetweenRays, intersectRayPlane } from './utils/math/Ray.js';

--- a/src/utils/geodesy.ts
+++ b/src/utils/geodesy.ts
@@ -1,0 +1,51 @@
+import { Vector3 } from './math/Vector3.js';
+
+const WGS84_A = 6378137.0;
+const WGS84_E2 = 6.69437999014e-3;
+
+export interface Geodetic {
+  latitude: number;
+  longitude: number;
+  height: number;
+}
+
+export function cartesianToGeodetic(position: Vector3): Geodetic {
+  const x = position.x;
+  const y = position.y;
+  const z = position.z;
+
+  const longitude = Math.atan2(y, x);
+  const p = Math.sqrt(x * x + y * y);
+  const theta = Math.atan2(z * WGS84_A, p * WGS84_A * (1 - WGS84_E2));
+  const sinTheta = Math.sin(theta);
+  const cosTheta = Math.cos(theta);
+
+  const latitude = Math.atan2(
+    z + WGS84_E2 * (1 - WGS84_E2) * WGS84_A * sinTheta * sinTheta * sinTheta,
+    p - WGS84_E2 * WGS84_A * cosTheta * cosTheta * cosTheta
+  );
+
+  const sinLat = Math.sin(latitude);
+  const N = WGS84_A / Math.sqrt(1 - WGS84_E2 * sinLat * sinLat);
+  const height = p / Math.cos(latitude) - N;
+
+  return { latitude, longitude, height };
+}
+
+export function eastNorthUp(position: Vector3): { east: Vector3; north: Vector3; up: Vector3 } {
+  const { latitude, longitude } = cartesianToGeodetic(position);
+  const cosLat = Math.cos(latitude);
+  const sinLat = Math.sin(latitude);
+  const cosLon = Math.cos(longitude);
+  const sinLon = Math.sin(longitude);
+
+  const east = new Vector3(-sinLon, cosLon, 0);
+  const north = new Vector3(-sinLat * cosLon, -sinLat * sinLon, cosLat);
+  const up = new Vector3(cosLat * cosLon, cosLat * sinLon, sinLat);
+
+  return {
+    east: east.normalize(),
+    north: north.normalize(),
+    up: up.normalize()
+  };
+}

--- a/src/utils/math/Matrix4.ts
+++ b/src/utils/math/Matrix4.ts
@@ -1,0 +1,173 @@
+import { Quaternion } from './Quaternion.js';
+import { Vector3 } from './Vector3.js';
+
+export class Matrix4 {
+  constructor(public elements: number[]) {
+    if (elements.length !== 16) {
+      throw new Error('Matrix4 requires 16 elements');
+    }
+  }
+
+  static identity(): Matrix4 {
+    return new Matrix4([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]);
+  }
+
+  static fromTranslationRotationScale(translation: Vector3, rotation: Quaternion, scale: Vector3): Matrix4 {
+    const q = rotation.normalize();
+    const s = scale;
+    const x = q.x;
+    const y = q.y;
+    const z = q.z;
+    const w = q.w;
+
+    const x2 = x + x;
+    const y2 = y + y;
+    const z2 = z + z;
+
+    const xx = x * x2;
+    const xy = x * y2;
+    const xz = x * z2;
+    const yy = y * y2;
+    const yz = y * z2;
+    const zz = z * z2;
+    const wx = w * x2;
+    const wy = w * y2;
+    const wz = w * z2;
+
+    return new Matrix4([
+      (1 - (yy + zz)) * s.x, (xy + wz) * s.y, (xz - wy) * s.z, 0,
+      (xy - wz) * s.x, (1 - (xx + zz)) * s.y, (yz + wx) * s.z, 0,
+      (xz + wy) * s.x, (yz - wx) * s.y, (1 - (xx + yy)) * s.z, 0,
+      translation.x, translation.y, translation.z, 1
+    ]);
+  }
+
+  static fromArray(array: number[]): Matrix4 {
+    return new Matrix4([...array]);
+  }
+
+  clone(): Matrix4 {
+    return new Matrix4([...this.elements]);
+  }
+
+  multiply(other: Matrix4): Matrix4 {
+    const a = this.elements;
+    const b = other.elements;
+    const result = new Array<number>(16).fill(0);
+
+    for (let row = 0; row < 4; row++) {
+      for (let col = 0; col < 4; col++) {
+        let sum = 0;
+        for (let i = 0; i < 4; i++) {
+          sum += a[row + i * 4] * b[i + col * 4];
+        }
+        result[row + col * 4] = sum;
+      }
+    }
+
+    return new Matrix4(result);
+  }
+
+  transformVector(v: Vector3): Vector3 {
+    const e = this.elements;
+    const x = v.x;
+    const y = v.y;
+    const z = v.z;
+    const tx = e[0] * x + e[4] * y + e[8] * z + e[12];
+    const ty = e[1] * x + e[5] * y + e[9] * z + e[13];
+    const tz = e[2] * x + e[6] * y + e[10] * z + e[14];
+    return new Vector3(tx, ty, tz);
+  }
+
+  getTranslation(): Vector3 {
+    return new Vector3(this.elements[12], this.elements[13], this.elements[14]);
+  }
+
+  getRotation(): Quaternion {
+    const e = this.elements;
+    const sx = Vector3.fromArray([e[0], e[1], e[2]]).length();
+    const sy = Vector3.fromArray([e[4], e[5], e[6]]).length();
+    const sz = Vector3.fromArray([e[8], e[9], e[10]]).length();
+
+    const invSx = sx === 0 ? 0 : 1 / sx;
+    const invSy = sy === 0 ? 0 : 1 / sy;
+    const invSz = sz === 0 ? 0 : 1 / sz;
+
+    const m = [
+      e[0] * invSx, e[4] * invSy, e[8] * invSz,
+      e[1] * invSx, e[5] * invSy, e[9] * invSz,
+      e[2] * invSx, e[6] * invSy, e[10] * invSz
+    ];
+    return Quaternion.fromMatrix3(m);
+  }
+
+  getScale(): Vector3 {
+    const e = this.elements;
+    return new Vector3(
+      Vector3.fromArray([e[0], e[1], e[2]]).length(),
+      Vector3.fromArray([e[4], e[5], e[6]]).length(),
+      Vector3.fromArray([e[8], e[9], e[10]]).length()
+    );
+  }
+
+  invert(): Matrix4 {
+    const m = this.elements;
+    const inv = new Array<number>(16);
+
+    inv[0] = m[5] * m[10] * m[15] - m[5] * m[11] * m[14] - m[9] * m[6] * m[15] + m[9] * m[7] * m[14] + m[13] * m[6] * m[11] - m[13] * m[7] * m[10];
+    inv[4] = -m[4] * m[10] * m[15] + m[4] * m[11] * m[14] + m[8] * m[6] * m[15] - m[8] * m[7] * m[14] - m[12] * m[6] * m[11] + m[12] * m[7] * m[10];
+    inv[8] = m[4] * m[9] * m[15] - m[4] * m[11] * m[13] - m[8] * m[5] * m[15] + m[8] * m[7] * m[13] + m[12] * m[5] * m[11] - m[12] * m[7] * m[9];
+    inv[12] = -m[4] * m[9] * m[14] + m[4] * m[10] * m[13] + m[8] * m[5] * m[14] - m[8] * m[6] * m[13] - m[12] * m[5] * m[10] + m[12] * m[6] * m[9];
+
+    inv[1] = -m[1] * m[10] * m[15] + m[1] * m[11] * m[14] + m[9] * m[2] * m[15] - m[9] * m[3] * m[14] - m[13] * m[2] * m[11] + m[13] * m[3] * m[10];
+    inv[5] = m[0] * m[10] * m[15] - m[0] * m[11] * m[14] - m[8] * m[2] * m[15] + m[8] * m[3] * m[14] + m[12] * m[2] * m[11] - m[12] * m[3] * m[10];
+    inv[9] = -m[0] * m[9] * m[15] + m[0] * m[11] * m[13] + m[8] * m[1] * m[15] - m[8] * m[3] * m[13] - m[12] * m[1] * m[11] + m[12] * m[3] * m[9];
+    inv[13] = m[0] * m[9] * m[14] - m[0] * m[10] * m[13] - m[8] * m[1] * m[14] + m[8] * m[2] * m[13] + m[12] * m[1] * m[10] - m[12] * m[2] * m[9];
+
+    inv[2] = m[1] * m[6] * m[15] - m[1] * m[7] * m[14] - m[5] * m[2] * m[15] + m[5] * m[3] * m[14] + m[13] * m[2] * m[7] - m[13] * m[3] * m[6];
+    inv[6] = -m[0] * m[6] * m[15] + m[0] * m[7] * m[14] + m[4] * m[2] * m[15] - m[4] * m[3] * m[14] - m[12] * m[2] * m[7] + m[12] * m[3] * m[6];
+    inv[10] = m[0] * m[5] * m[15] - m[0] * m[7] * m[13] - m[4] * m[1] * m[15] + m[4] * m[3] * m[13] + m[12] * m[1] * m[7] - m[12] * m[3] * m[5];
+    inv[14] = -m[0] * m[5] * m[14] + m[0] * m[6] * m[13] + m[4] * m[1] * m[14] - m[4] * m[2] * m[13] - m[12] * m[1] * m[6] + m[12] * m[2] * m[5];
+
+    inv[3] = -m[1] * m[6] * m[11] + m[1] * m[7] * m[10] + m[5] * m[2] * m[11] - m[5] * m[3] * m[10] - m[9] * m[2] * m[7] + m[9] * m[3] * m[6];
+    inv[7] = m[0] * m[6] * m[11] - m[0] * m[7] * m[10] - m[4] * m[2] * m[11] + m[4] * m[3] * m[10] + m[8] * m[2] * m[7] - m[8] * m[3] * m[6];
+    inv[11] = -m[0] * m[5] * m[11] + m[0] * m[7] * m[9] + m[4] * m[1] * m[11] - m[4] * m[3] * m[9] - m[8] * m[1] * m[7] + m[8] * m[3] * m[5];
+    inv[15] = m[0] * m[5] * m[10] - m[0] * m[6] * m[9] - m[4] * m[1] * m[10] + m[4] * m[2] * m[9] + m[8] * m[1] * m[6] - m[8] * m[2] * m[5];
+
+    let det = m[0] * inv[0] + m[1] * inv[4] + m[2] * inv[8] + m[3] * inv[12];
+
+    if (det === 0) {
+      throw new Error('Matrix not invertible');
+    }
+
+    det = 1 / det;
+    for (let i = 0; i < 16; i++) {
+      inv[i] *= det;
+    }
+
+    return new Matrix4(inv);
+  }
+
+  transpose(): Matrix4 {
+    const m = this.elements;
+    return new Matrix4([
+      m[0], m[4], m[8], m[12],
+      m[1], m[5], m[9], m[13],
+      m[2], m[6], m[10], m[14],
+      m[3], m[7], m[11], m[15]
+    ]);
+  }
+}
+
+export function matrix4FromArray(array: number[]): Matrix4 {
+  return Matrix4.fromArray(array);
+}
+
+export function matrix4ToArray(matrix: Matrix4): number[] {
+  return [...matrix.elements];
+}

--- a/src/utils/math/Quaternion.ts
+++ b/src/utils/math/Quaternion.ts
@@ -1,0 +1,183 @@
+import { Vector3 } from './Vector3.js';
+
+export class Quaternion {
+  constructor(
+    public w: number,
+    public x: number,
+    public y: number,
+    public z: number
+  ) {}
+
+  static identity(): Quaternion {
+    return new Quaternion(1, 0, 0, 0);
+  }
+
+  static fromAxisAngle(axis: Vector3, angle: number): Quaternion {
+    const half = angle / 2;
+    const s = Math.sin(half);
+    const normalized = axis.normalize();
+    return new Quaternion(
+      Math.cos(half),
+      normalized.x * s,
+      normalized.y * s,
+      normalized.z * s
+    );
+  }
+
+  static fromEuler(heading: number, pitch: number, roll: number): Quaternion {
+    const ch = Math.cos(heading / 2);
+    const sh = Math.sin(heading / 2);
+    const cp = Math.cos(pitch / 2);
+    const sp = Math.sin(pitch / 2);
+    const cr = Math.cos(roll / 2);
+    const sr = Math.sin(roll / 2);
+
+    return new Quaternion(
+      ch * cp * cr + sh * sp * sr,
+      sh * cp * cr - ch * sp * sr,
+      ch * sp * cr + sh * cp * sr,
+      ch * cp * sr - sh * sp * cr
+    );
+  }
+
+  clone(): Quaternion {
+    return new Quaternion(this.w, this.x, this.y, this.z);
+  }
+
+  multiply(q: Quaternion): Quaternion {
+    const w = this.w * q.w - this.x * q.x - this.y * q.y - this.z * q.z;
+    const x = this.w * q.x + this.x * q.w + this.y * q.z - this.z * q.y;
+    const y = this.w * q.y - this.x * q.z + this.y * q.w + this.z * q.x;
+    const z = this.w * q.z + this.x * q.y - this.y * q.x + this.z * q.w;
+    return new Quaternion(w, x, y, z);
+  }
+
+  inverse(): Quaternion {
+    const normSq =
+      this.w * this.w + this.x * this.x + this.y * this.y + this.z * this.z;
+    return new Quaternion(this.w / normSq, -this.x / normSq, -this.y / normSq, -this.z / normSq);
+  }
+
+  normalize(): Quaternion {
+    const length = Math.sqrt(
+      this.w * this.w + this.x * this.x + this.y * this.y + this.z * this.z
+    );
+    if (length === 0) {
+      return Quaternion.identity();
+    }
+    return new Quaternion(this.w / length, this.x / length, this.y / length, this.z / length);
+  }
+
+  rotateVector(v: Vector3): Vector3 {
+    const qVec = new Vector3(this.x, this.y, this.z);
+    const uv = qVec.cross(v);
+    const uuv = qVec.cross(uv);
+    const uvScaled = uv.multiplyByScalar(2 * this.w);
+    const uuvScaled = uuv.multiplyByScalar(2);
+    return v.add(uvScaled).add(uuvScaled);
+  }
+
+  toMatrix3(): number[] {
+    const { w, x, y, z } = this.normalize();
+    const xx = x * x;
+    const yy = y * y;
+    const zz = z * z;
+    const xy = x * y;
+    const xz = x * z;
+    const yz = y * z;
+    const wx = w * x;
+    const wy = w * y;
+    const wz = w * z;
+
+    return [
+      1 - 2 * (yy + zz),
+      2 * (xy - wz),
+      2 * (xz + wy),
+      2 * (xy + wz),
+      1 - 2 * (xx + zz),
+      2 * (yz - wx),
+      2 * (xz - wy),
+      2 * (yz + wx),
+      1 - 2 * (xx + yy)
+    ];
+  }
+
+  static fromMatrix3(m: number[]): Quaternion {
+    const m00 = m[0];
+    const m11 = m[4];
+    const m22 = m[8];
+    const trace = m00 + m11 + m22;
+
+    if (trace > 0) {
+      const s = Math.sqrt(trace + 1) * 2;
+      const w = 0.25 * s;
+      const x = (m[7] - m[5]) / s;
+      const y = (m[2] - m[6]) / s;
+      const z = (m[3] - m[1]) / s;
+      return new Quaternion(w, x, y, z).normalize();
+    }
+
+    if (m00 > m11 && m00 > m22) {
+      const s = Math.sqrt(1 + m00 - m11 - m22) * 2;
+      const w = (m[7] - m[5]) / s;
+      const x = 0.25 * s;
+      const y = (m[1] + m[3]) / s;
+      const z = (m[2] + m[6]) / s;
+      return new Quaternion(w, x, y, z).normalize();
+    }
+
+    if (m11 > m22) {
+      const s = Math.sqrt(1 + m11 - m00 - m22) * 2;
+      const w = (m[2] - m[6]) / s;
+      const x = (m[1] + m[3]) / s;
+      const y = 0.25 * s;
+      const z = (m[5] + m[7]) / s;
+      return new Quaternion(w, x, y, z).normalize();
+    }
+
+    const s = Math.sqrt(1 + m22 - m00 - m11) * 2;
+    const w = (m[3] - m[1]) / s;
+    const x = (m[2] + m[6]) / s;
+    const y = (m[5] + m[7]) / s;
+    const z = 0.25 * s;
+    return new Quaternion(w, x, y, z).normalize();
+  }
+
+  static slerp(a: Quaternion, b: Quaternion, t: number): Quaternion {
+    let cosTheta = a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z;
+    let end = b;
+    if (cosTheta < 0) {
+      cosTheta = -cosTheta;
+      end = new Quaternion(-b.w, -b.x, -b.y, -b.z);
+    }
+
+    if (1 - cosTheta < 1e-6) {
+      return new Quaternion(
+        a.w + t * (end.w - a.w),
+        a.x + t * (end.x - a.x),
+        a.y + t * (end.y - a.y),
+        a.z + t * (end.z - a.z)
+      ).normalize();
+    }
+
+    const theta = Math.acos(cosTheta);
+    const sinTheta = Math.sin(theta);
+    const weightA = Math.sin((1 - t) * theta) / sinTheta;
+    const weightB = Math.sin(t * theta) / sinTheta;
+
+    return new Quaternion(
+      a.w * weightA + end.w * weightB,
+      a.x * weightA + end.x * weightB,
+      a.y * weightA + end.y * weightB,
+      a.z * weightA + end.z * weightB
+    ).normalize();
+  }
+}
+
+export function quaternionFromArray(arr: [number, number, number, number]): Quaternion {
+  return new Quaternion(arr[0], arr[1], arr[2], arr[3]);
+}
+
+export function quaternionToArray(q: Quaternion): [number, number, number, number] {
+  return [q.w, q.x, q.y, q.z];
+}

--- a/src/utils/math/Ray.ts
+++ b/src/utils/math/Ray.ts
@@ -1,0 +1,57 @@
+import { Vector3 } from './Vector3.js';
+
+export interface Ray {
+  origin: Vector3;
+  direction: Vector3;
+}
+
+export function closestPointsBetweenRays(
+  rayA: Ray,
+  rayB: Ray
+): { pointA: Vector3; pointB: Vector3; distance: number; parameterA: number; parameterB: number } {
+  const p13 = rayA.origin.subtract(rayB.origin);
+  const d1 = rayA.direction.normalize();
+  const d2 = rayB.direction.normalize();
+
+  const d1343 = p13.dot(d2);
+  const d4321 = d2.dot(d1);
+  const d1321 = p13.dot(d1);
+  const d4343 = d2.dot(d2);
+  const d2121 = d1.dot(d1);
+
+  const denom = d2121 * d4343 - d4321 * d4321;
+  if (Math.abs(denom) < 1e-8) {
+    return {
+      pointA: rayA.origin,
+      pointB: rayB.origin,
+      distance: p13.length(),
+      parameterA: 0,
+      parameterB: 0
+    };
+  }
+
+  const numer = d1343 * d4321 - d1321 * d4343;
+
+  const mua = numer / denom;
+  const mub = (d1343 + d4321 * mua) / d4343;
+
+  const pointA = rayA.origin.add(d1.multiplyByScalar(mua));
+  const pointB = rayB.origin.add(d2.multiplyByScalar(mub));
+
+  return {
+    pointA,
+    pointB,
+    distance: Vector3.distance(pointA, pointB),
+    parameterA: mua,
+    parameterB: mub
+  };
+}
+
+export function intersectRayPlane(ray: Ray, planePoint: Vector3, planeNormal: Vector3): Vector3 | undefined {
+  const denom = planeNormal.dot(ray.direction);
+  if (Math.abs(denom) < 1e-8) {
+    return undefined;
+  }
+  const t = planePoint.subtract(ray.origin).dot(planeNormal) / denom;
+  return ray.origin.add(ray.direction.multiplyByScalar(t));
+}

--- a/src/utils/math/Vector3.ts
+++ b/src/utils/math/Vector3.ts
@@ -1,0 +1,114 @@
+export class Vector3 {
+  constructor(public x: number, public y: number, public z: number) {}
+
+  static zero(): Vector3 {
+    return new Vector3(0, 0, 0);
+  }
+
+  static fromArray(arr: [number, number, number]): Vector3 {
+    return new Vector3(arr[0], arr[1], arr[2]);
+  }
+
+  clone(): Vector3 {
+    return new Vector3(this.x, this.y, this.z);
+  }
+
+  toArray(): [number, number, number] {
+    return [this.x, this.y, this.z];
+  }
+
+  add(v: Vector3): Vector3 {
+    return new Vector3(this.x + v.x, this.y + v.y, this.z + v.z);
+  }
+
+  subtract(v: Vector3): Vector3 {
+    return new Vector3(this.x - v.x, this.y - v.y, this.z - v.z);
+  }
+
+  multiplyByScalar(s: number): Vector3 {
+    return new Vector3(this.x * s, this.y * s, this.z * s);
+  }
+
+  divideByScalar(s: number): Vector3 {
+    return new Vector3(this.x / s, this.y / s, this.z / s);
+  }
+
+  dot(v: Vector3): number {
+    return this.x * v.x + this.y * v.y + this.z * v.z;
+  }
+
+  cross(v: Vector3): Vector3 {
+    return new Vector3(
+      this.y * v.z - this.z * v.y,
+      this.z * v.x - this.x * v.z,
+      this.x * v.y - this.y * v.x
+    );
+  }
+
+  length(): number {
+    return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+  }
+
+  lengthSquared(): number {
+    return this.x * this.x + this.y * this.y + this.z * this.z;
+  }
+
+  normalize(): Vector3 {
+    const len = this.length();
+    if (len === 0) {
+      return new Vector3(0, 0, 0);
+    }
+    return this.divideByScalar(len);
+  }
+
+  static normalize(v: Vector3): Vector3 {
+    return v.normalize();
+  }
+
+  static distance(a: Vector3, b: Vector3): number {
+    return a.subtract(b).length();
+  }
+
+  static lerp(a: Vector3, b: Vector3, t: number): Vector3 {
+    return new Vector3(
+      a.x + (b.x - a.x) * t,
+      a.y + (b.y - a.y) * t,
+      a.z + (b.z - a.z) * t
+    );
+  }
+
+  static projectOntoVector(v: Vector3, onto: Vector3): Vector3 {
+    const normalized = onto.normalize();
+    const scalar = v.dot(normalized);
+    return normalized.multiplyByScalar(scalar);
+  }
+
+  static rejectFromVector(v: Vector3, from: Vector3): Vector3 {
+    return v.subtract(Vector3.projectOntoVector(v, from));
+  }
+
+  static angleBetween(a: Vector3, b: Vector3): number {
+    const denom = Math.sqrt(a.lengthSquared() * b.lengthSquared());
+    if (denom === 0) {
+      return 0;
+    }
+    const cosTheta = Math.min(1, Math.max(-1, a.dot(b) / denom));
+    return Math.acos(cosTheta);
+  }
+
+  static equalsEpsilon(a: Vector3, b: Vector3, epsilon = 1e-8): boolean {
+    return (
+      Math.abs(a.x - b.x) <= epsilon &&
+      Math.abs(a.y - b.y) <= epsilon &&
+      Math.abs(a.z - b.z) <= epsilon
+    );
+  }
+}
+
+export function fromArray(array: [number, number, number]): Vector3 {
+  return Vector3.fromArray(array);
+}
+
+export function toArray(v: Vector3): [number, number, number] {
+  return v.toArray();
+}

--- a/src/utils/math/index.ts
+++ b/src/utils/math/index.ts
@@ -1,0 +1,4 @@
+export * from './Vector3.js';
+export * from './Quaternion.js';
+export * from './Matrix4.js';
+export * from './Ray.js';

--- a/tests/run-tests.ts
+++ b/tests/run-tests.ts
@@ -1,0 +1,201 @@
+import { TransformSolver } from '../src/core/TransformSolver.js';
+import { FrameState, TransformSession } from '../src/core/types.js';
+import { Snapper } from '../src/core/Snapper.js';
+import { Vector3 } from '../src/utils/math/Vector3.js';
+import { Quaternion } from '../src/utils/math/Quaternion.js';
+
+declare const process: any;
+
+interface TestCase {
+  name: string;
+  fn: () => void;
+}
+
+const tests: TestCase[] = [];
+
+function test(name: string, fn: () => void): void {
+  tests.push({ name, fn });
+}
+
+function expectVector(actual: [number, number, number], expected: [number, number, number], epsilon = 1e-5): void {
+  for (let i = 0; i < 3; i++) {
+    if (Math.abs(actual[i] - expected[i]) > epsilon) {
+      throw new Error(`Vector mismatch at index ${i}: expected ${expected[i]}, got ${actual[i]}`);
+    }
+  }
+}
+
+function expectQuaternion(actual: [number, number, number, number], expected: [number, number, number, number], epsilon = 1e-5): void {
+  const direct = actual.every((value, index) => Math.abs(value - expected[index]) <= epsilon);
+  if (direct) {
+    return;
+  }
+  const negated = actual.every((value, index) => Math.abs(value + expected[index]) <= epsilon);
+  if (!negated) {
+    throw new Error(`Quaternion mismatch: expected ${expected} got ${actual}`);
+  }
+}
+
+function createFrame(): FrameState {
+  return {
+    pivot: [0, 0, 0],
+    axes: {
+      x: [1, 0, 0],
+      y: [0, 1, 0],
+      z: [0, 0, 1]
+    },
+    matrix: [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ]
+  };
+}
+
+test('axis translation solves correctly', () => {
+  const solver = new TransformSolver();
+  const session: TransformSession = { mode: 'translate', axis: 'x' };
+  const frame = createFrame();
+  const snapper = new Snapper();
+  solver.begin({
+    session,
+    frame,
+    startRay: {
+      origin: new Vector3(0, 0, 5),
+      direction: new Vector3(0, 0, -1)
+    },
+    snapper
+  });
+  const delta = solver.update({
+    currentRay: {
+      origin: new Vector3(2, 0, 5),
+      direction: new Vector3(0, 0, -1)
+    }
+  });
+  expectVector(delta.translation, [2, 0, 0]);
+  expectQuaternion(delta.rotation, [1, 0, 0, 0]);
+  expectVector(delta.scale, [1, 1, 1]);
+});
+
+test('plane translation solves correctly', () => {
+  const solver = new TransformSolver();
+  const session: TransformSession = { mode: 'translate', planeAxes: ['x', 'y'] };
+  const frame = createFrame();
+  const snapper = new Snapper();
+  solver.begin({
+    session,
+    frame,
+    startRay: {
+      origin: new Vector3(0, 0, 5),
+      direction: new Vector3(0, 0, -1)
+    },
+    snapper
+  });
+  const delta = solver.update({
+    currentRay: {
+      origin: new Vector3(3, 4, 5),
+      direction: new Vector3(0, 0, -1)
+    }
+  });
+  expectVector(delta.translation, [3, 4, 0]);
+});
+
+test('axis rotation solves correctly', () => {
+  const solver = new TransformSolver();
+  const session: TransformSession = { mode: 'rotate', axis: 'z' };
+  const frame = createFrame();
+  const snapper = new Snapper();
+  solver.begin({
+    session,
+    frame,
+    startRay: {
+      origin: new Vector3(1, 0, 5),
+      direction: new Vector3(0, 0, -1)
+    },
+    snapper
+  });
+  const delta = solver.update({
+    currentRay: {
+      origin: new Vector3(0, 1, 5),
+      direction: new Vector3(0, 0, -1)
+    }
+  });
+  const expectedAngle = Math.PI / 2;
+  const expectedQuat = Quaternion.fromAxisAngle(new Vector3(0, 0, 1), expectedAngle);
+  expectQuaternion(delta.rotation, [expectedQuat.w, expectedQuat.x, expectedQuat.y, expectedQuat.z]);
+});
+
+test('view rotation solves correctly', () => {
+  const solver = new TransformSolver();
+  const session: TransformSession = {
+    mode: 'rotate',
+    viewNormal: [0, 0, 1]
+  };
+  const frame = createFrame();
+  const snapper = new Snapper();
+  solver.begin({
+    session,
+    frame,
+    startRay: {
+      origin: new Vector3(1, 0, 5),
+      direction: new Vector3(0, 0, -1)
+    },
+    snapper
+  });
+  const delta = solver.update({
+    currentRay: {
+      origin: new Vector3(0, 1, 5),
+      direction: new Vector3(0, 0, -1)
+    }
+  });
+  const expected = Quaternion.fromAxisAngle(new Vector3(0, 0, 1), Math.PI / 2);
+  expectQuaternion(delta.rotation, [expected.w, expected.x, expected.y, expected.z]);
+});
+
+test('axis scale solves correctly', () => {
+  const solver = new TransformSolver();
+  const session: TransformSession = { mode: 'scale', axis: 'x' };
+  const frame = createFrame();
+  const snapper = new Snapper();
+  solver.begin({
+    session,
+    frame,
+    startRay: {
+      origin: new Vector3(0, 0, 5),
+      direction: new Vector3(0, 0, -1)
+    },
+    snapper
+  });
+  const delta = solver.update({
+    currentRay: {
+      origin: new Vector3(1, 0, 5),
+      direction: new Vector3(0, 0, -1)
+    }
+  });
+  expectVector(delta.scale, [2, 1, 1]);
+});
+
+async function run(): Promise<void> {
+  let passed = 0;
+  for (const testCase of tests) {
+    try {
+      await testCase.fn();
+      console.log(`✔ ${testCase.name}`);
+      passed++;
+    } catch (error) {
+      console.error(`✖ ${testCase.name}:`, (error as Error).message);
+      process.exitCode = 1;
+      break;
+    }
+  }
+  if (process.exitCode && process.exitCode !== 0) {
+    throw new Error('Tests failed');
+  }
+  console.log(`${passed} tests passed`);
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- implement math utilities, snapping, frame building, and solving logic for a configurable Cesium universal manipulator
- add rendering, picking, controller state machine, and public API wrapper with cursor, pivot, orientation, and sizing controls
- provide TypeScript build, example Cesium demo page, and unit tests covering translate/rotate/scale solvers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d023fe01ec832d9f1c5f8eed57dd87